### PR TITLE
Fixed jitter buffer initial timestmap calculation and VAD extension

### DIFF
--- a/lib/membrane/rtp/jitter_buffer.ex
+++ b/lib/membrane/rtp/jitter_buffer.ex
@@ -44,7 +44,7 @@ defmodule Membrane.RTP.JitterBuffer do
               waiting?: true,
               max_latency_timer: nil,
               timestamp_base: nil,
-              previous_timestamp: -1,
+              previous_timestamp: nil,
               stats_acc: %{expected_prior: 0, received_prior: 0, last_transit: nil, jitter: 0.0}
 
     @type t :: %__MODULE__{
@@ -191,9 +191,9 @@ defmodule Membrane.RTP.JitterBuffer do
   end
 
   defp record_to_action(%Record{buffer: buffer}, state) do
-    %{previous_timestamp: previous_timestamp} = state
     %{timestamp: rtp_timestamp} = buffer.metadata.rtp
     timestamp_base = state.timestamp_base || rtp_timestamp
+    previous_timestamp = state.previous_timestamp || rtp_timestamp
 
     # timestamps in RTP don't have to be monotonic therefore there can be
     # a situation where in 2 consecutive packets the latter packet will have smaller timestamp

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -102,7 +102,7 @@ defmodule Membrane.RTP.VAD do
 
   defp filter_old_audio_levels(state) do
     Enum.reduce_while(state.audio_levels, state, fn {level, timestamp}, state ->
-      if state.current_timestamp - timestamp > state.time_window do
+      if Ratio.sub(state.current_timestamp, timestamp) |> Ratio.gt?(state.time_window) do
         {_level, audio_levels} = Qex.pop(state.audio_levels)
 
         state = %{

--- a/test/membrane/rtp/jitter_buffer/timestamps_calculation_test.exs
+++ b/test/membrane/rtp/jitter_buffer/timestamps_calculation_test.exs
@@ -24,7 +24,7 @@ defmodule Membrane.RTP.JitterBuffer.TimestampsCalculationTest do
         state
       end)
 
-    {{:ok, actions}, state} = JitterBuffer.handle_other(:send_buffers, %{}, state)
+    {{:ok, actions}, _state} = JitterBuffer.handle_other(:send_buffers, %{}, state)
 
     actions
     |> action_buffers()
@@ -54,6 +54,17 @@ defmodule Membrane.RTP.JitterBuffer.TimestampsCalculationTest do
       buffer2 = BufferFactory.sample_buffer(seq_num + 2)
 
       [state: state, buffer1: buffer1, buffer2: buffer2]
+    end
+
+    test "come in first", ctx do
+      %{buffer1: buffer1, buffer2: buffer2} = ctx
+
+      [timestamp1, timestamp2] =
+        [buffer1, buffer2]
+        |> process_and_receive_buffer_timestamps(ctx.state)
+
+      assert Ratio.equal?(timestamp1, 0)
+      assert Ratio.gt?(timestamp2, 0)
     end
 
     test "have monotonic timestamps within proper range", ctx do


### PR DESCRIPTION
Closes #54 

Besides fixing JitterBuffer's handling of first packet causing timestamp to go negative also added timestmap handling inside VAD extension to operate on `Ratio` numbers instead of simple integers.