### PR TITLE
Access timestamp from buffer.metadata.rtp in VAD

### DIFF
--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -91,7 +91,7 @@ defmodule Membrane.RTP.VAD do
     <<_id::4, _len::4, _v::1, level::7, _rest::binary-size(2)>> =
       buffer.metadata.rtp.extension.data
 
-    state = %{state | current_timestamp: buffer.metadata.timestamp}
+    state = %{state | current_timestamp: buffer.metadata.rtp.timestamp}
     state = filter_old_audio_levels(state)
     state = add_new_audio_level(state, level)
     audio_levels_vad = get_audio_levels_vad(state)


### PR DESCRIPTION
When integrating the latest version of membrane_rtp_plugin into a project, I encountered the following error:

```
[error] GenServer #PID<0.1650.0> terminating
** (KeyError) key :timestamp not found in: %{rtp: %{csrcs: [], extension: %Membrane.RTP.Header.Extension{data: <<16, 255, 0, 0>>, profile_specific: <<190, 222>>}, has_padding?: false, marker: true, payload_type: 111, sequence_numb
er: 7508, ssrc: 950946435, timestamp: 984164149, total_header_size: 20}}
    (membrane_rtp_plugin 0.8.0) lib/membrane/rtp/vad.ex:98: Membrane.RTP.VAD.handle_process/4
    ...
```

I was able to trace it down to here. Timestamps are present in the `rtp` map, but not as a top level key. Changing this fixes the issue.