### PR TITLE
Handle extensions

### DIFF
--- a/lib/membrane/rtp/header.ex
+++ b/lib/membrane/rtp/header.ex
@@ -53,7 +53,7 @@ defmodule Membrane.RTP.Header do
           timestamp: timestamp_t(),
           sequence_number: sequence_number_t(),
           csrcs: [RTP.ssrc_t()],
-          extension: __MODULE__.Extension.t() | nil
+          extensions: [__MODULE__.Extension.t()]
         }
 
   @enforce_keys [
@@ -67,6 +67,6 @@ defmodule Membrane.RTP.Header do
                 version: 2,
                 marker: false,
                 csrcs: [],
-                extension: nil
+                extensions: []
               ]
 end

--- a/lib/membrane/rtp/header_extension.ex
+++ b/lib/membrane/rtp/header_extension.ex
@@ -17,7 +17,7 @@ defmodule Membrane.RTP.Header.Extension do
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
-          identifier: binary(),
+          identifier: 1..14,
           data: binary()
         }
 end

--- a/lib/membrane/rtp/header_extension.ex
+++ b/lib/membrane/rtp/header_extension.ex
@@ -13,11 +13,11 @@ defmodule Membrane.RTP.Header.Extension do
 
   ```
   """
-  @enforce_keys [:profile_specific, :data]
+  @enforce_keys [:identifier, :data]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
-          profile_specific: binary(),
+          identifier: binary(),
           data: binary()
         }
 end

--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -77,7 +77,7 @@ defmodule Membrane.RTP.Packet do
 
   defp serialize_header_extension(%Header.Extension{data: data} = extension) do
     data_size = byte_size(data) - 1
-    <<extension.profile_specific::integer-size(4), data_size::integer-size(4), data::binary>>
+    <<extension.identifier::integer-size(4), data_size::integer-size(4), data::binary>>
   end
 
   @spec parse(binary(), boolean()) ::
@@ -134,6 +134,7 @@ defmodule Membrane.RTP.Packet do
          true
        ) do
     extensions = parse_data_while_possible(data, [])
+    extensions = Enum.reverse(extensions)
     {:ok, {extensions, rest}}
   end
 
@@ -156,7 +157,7 @@ defmodule Membrane.RTP.Packet do
     else
       len_data = len_data + 1
       <<data::binary-size(len_data), next_extensions::binary>> = extensions
-      extension = %Header.Extension{profile_specific: local_identifier, data: data}
+      extension = %Header.Extension{identifier: local_identifier, data: data}
       {:ok, {extension, next_extensions}}
     end
   end

--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -153,7 +153,7 @@ defmodule Membrane.RTP.Packet do
   end
 
   defp parse_one_byte_header(
-         <<0::4, _len_data::integer-size(4), extension_header::bits-size(8), extensions::binary>>
+         <<0::4, _len_data::integer-size(4), _extension_header::bits-size(8), extensions::binary>>
        ),
        do: extensions
 

--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -136,19 +136,19 @@ defmodule Membrane.RTP.Packet do
            rest::binary>>,
          true
        ) do
-    extensions = parse_data_while_possible(data, [])
+    extensions = parse_extension_data(data, [])
     extensions = Enum.reverse(extensions)
     {:ok, {extensions, rest}}
   end
 
   defp parse_header_extension(_binary, true), do: :error
 
-  defp parse_data_while_possible(<<>>, acc), do: acc
+  defp parse_extension_data(<<>>, acc), do: acc
 
-  defp parse_data_while_possible(data, acc) do
+  defp parse_extension_data(data, acc) do
     case parse_one_byte_header(data) do
-      {data, rest} -> parse_data_while_possible(rest, [data | acc])
-      {rest} -> parse_data_while_possible(rest, acc)
+      {data, rest} -> parse_extension_data(rest, [data | acc])
+      rest -> parse_extension_data(rest, acc)
     end
   end
 
@@ -156,7 +156,7 @@ defmodule Membrane.RTP.Packet do
     <<local_identifier::integer-size(4), len_data::integer-size(4)>> = extension_header
 
     if local_identifier == 0 do
-      {extensions}
+      extensions
     else
       len_data = len_data + 1
       <<data::binary-size(len_data), next_extensions::binary>> = extensions

--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -152,16 +152,17 @@ defmodule Membrane.RTP.Packet do
     end
   end
 
-  defp parse_one_byte_header(<<extension_header::bits-size(8), extensions::binary>>) do
-    <<local_identifier::integer-size(4), len_data::integer-size(4)>> = extension_header
+  defp parse_one_byte_header(
+         <<0::4, _len_data::integer-size(4), extension_header::bits-size(8), extensions::binary>>
+       ),
+       do: extensions
 
-    if local_identifier == 0 do
-      extensions
-    else
-      len_data = len_data + 1
-      <<data::binary-size(len_data), next_extensions::binary>> = extensions
-      extension = %Header.Extension{identifier: local_identifier, data: data}
-      {extension, next_extensions}
-    end
+  defp parse_one_byte_header(
+         <<local_identifier::integer-size(4), len_data::integer-size(4), extensions::binary>>
+       ) do
+    len_data = len_data + 1
+    <<data::binary-size(len_data), next_extensions::binary>> = extensions
+    extension = %Header.Extension{identifier: local_identifier, data: data}
+    {extension, next_extensions}
   end
 end

--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -2,6 +2,9 @@ defmodule Membrane.RTP.Packet do
   @moduledoc """
   Defines a struct describing an RTP packet and a way to parse and serialize it.
   Based on [RFC3550](https://tools.ietf.org/html/rfc3550#page-13)
+
+  Support only one-byte header from [RFC8285](https://www.rfc-editor.org/rfc/pdfrfc/rfc8285.txt.pdf), as according to document
+  this form is preferred and it must be supported by all receivers.
   """
 
   alias Membrane.RTP.{Header, Utils}
@@ -144,8 +147,8 @@ defmodule Membrane.RTP.Packet do
 
   defp parse_data_while_possible(data, acc) do
     case parse_one_byte_header(data) do
-      {:ok, {data, rest}} -> parse_data_while_possible(rest, [data | acc])
-      {:ok, rest} -> parse_data_while_possible(rest, acc)
+      {data, rest} -> parse_data_while_possible(rest, [data | acc])
+      {rest} -> parse_data_while_possible(rest, acc)
     end
   end
 
@@ -153,12 +156,12 @@ defmodule Membrane.RTP.Packet do
     <<local_identifier::integer-size(4), len_data::integer-size(4)>> = extension_header
 
     if local_identifier == 0 do
-      {:ok, extensions}
+      {extensions}
     else
       len_data = len_data + 1
       <<data::binary-size(len_data), next_extensions::binary>> = extensions
       extension = %Header.Extension{identifier: local_identifier, data: data}
-      {:ok, {extension, next_extensions}}
+      {extension, next_extensions}
     end
   end
 end

--- a/lib/membrane/rtp/parser.ex
+++ b/lib/membrane/rtp/parser.ex
@@ -30,7 +30,7 @@ defmodule Membrane.RTP.Parser do
     :csrcs,
     :payload_type,
     :marker,
-    :extension
+    :extensions
   ]
 
   def_options secure?: [
@@ -79,7 +79,6 @@ defmodule Membrane.RTP.Parser do
         |> Map.merge(%{has_padding?: has_padding?, total_header_size: total_header_size})
 
       metadata = Map.put(metadata, :rtp, rtp)
-
       {{:ok, buffer: {:output, %Buffer{payload: payload, metadata: metadata}}}, state}
     else
       :rtcp ->

--- a/lib/membrane/rtp/serializer.ex
+++ b/lib/membrane/rtp/serializer.ex
@@ -96,7 +96,7 @@ defmodule Membrane.RTP.Serializer do
       timestamp: rtp_timestamp,
       sequence_number: state.sequence_number,
       csrcs: Map.get(rtp_metadata, :csrcs, []),
-      extensions: [Map.get(rtp_metadata, :extension)]
+      extensions: Map.get(rtp_metadata, :extensions, [])
     }
 
     buffer = %Membrane.Buffer{

--- a/lib/membrane/rtp/serializer.ex
+++ b/lib/membrane/rtp/serializer.ex
@@ -96,7 +96,7 @@ defmodule Membrane.RTP.Serializer do
       timestamp: rtp_timestamp,
       sequence_number: state.sequence_number,
       csrcs: Map.get(rtp_metadata, :csrcs, []),
-      extension: Map.get(rtp_metadata, :extension)
+      extensions: [Map.get(rtp_metadata, :extension)]
     }
 
     buffer = %Membrane.Buffer{

--- a/lib/membrane/rtp/session_bin.ex
+++ b/lib/membrane/rtp/session_bin.ex
@@ -471,9 +471,14 @@ defmodule Membrane.RTP.SessionBin do
   end
 
   @impl true
-  def handle_notification({:new_rtp_stream, ssrc, payload_type}, :ssrc_router, _ctx, state) do
+  def handle_notification(
+        {:new_rtp_stream, ssrc, payload_type, extensions},
+        :ssrc_router,
+        _ctx,
+        state
+      ) do
     state = put_in(state.ssrc_pt_mapping[ssrc], payload_type)
-    {{:ok, notify: {:new_rtp_stream, ssrc, payload_type}}, state}
+    {{:ok, notify: {:new_rtp_stream, ssrc, payload_type, extensions}}, state}
   end
 
   @impl true

--- a/lib/membrane/rtp/silence_discarder.ex
+++ b/lib/membrane/rtp/silence_discarder.ex
@@ -86,7 +86,7 @@ defmodule Membrane.RTP.SilenceDiscarder do
       %{
         extension: %Header.Extension{
           # profile specific for one-byte extensions
-          profile_specific: <<0xBE, 0xDE>>,
+          identifier: <<0xBE, 0xDE>>,
           data: data
         }
       } ->

--- a/lib/membrane/rtp/ssrc_router.ex
+++ b/lib/membrane/rtp/ssrc_router.ex
@@ -99,9 +99,13 @@ defmodule Membrane.RTP.SSRCRouter do
 
   @impl true
   def handle_process(Pad.ref(:input, _id) = pad, buffer, _ctx, state) do
-    %Membrane.Buffer{metadata: %{rtp: %{ssrc: ssrc, payload_type: payload_type}}} = buffer
+    %Membrane.Buffer{
+      metadata: %{rtp: %{ssrc: ssrc, payload_type: payload_type, extensions: extensions}}
+    } = buffer
 
-    {new_stream_actions, state} = maybe_handle_new_stream(pad, ssrc, payload_type, state)
+    {new_stream_actions, state} =
+      maybe_handle_new_stream(pad, ssrc, payload_type, extensions, state)
+
     {actions, state} = maybe_add_to_linking_buffer(:buffer, buffer, ssrc, state)
     {{:ok, new_stream_actions ++ actions}, state}
   end
@@ -159,12 +163,13 @@ defmodule Membrane.RTP.SSRCRouter do
     super(pad, event, ctx, state)
   end
 
-  defp maybe_handle_new_stream(pad, ssrc, payload_type, state) do
+  defp maybe_handle_new_stream(pad, ssrc, payload_type, extensions, state) do
     if Map.has_key?(state.pads, ssrc) do
       {[], state}
     else
       state = state |> put_in([:pads, ssrc], pad) |> put_in([:linking_buffers, ssrc], [])
-      {[notify: {:new_rtp_stream, ssrc, payload_type}], state}
+
+      {[notify: {:new_rtp_stream, ssrc, payload_type, extensions}], state}
     end
   end
 

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -108,8 +108,8 @@ defmodule Membrane.RTP.VAD do
 
   @impl true
   def handle_process(:input, %Membrane.Buffer{} = buffer, _ctx, state) do
-    <<_id::4, _len::4, _v::1, level::7, _rest::binary-size(2)>> =
-      buffer.metadata.rtp.extension.data
+    vad_extension = Enum.find(buffer.metadata.rtp.extensions, &(&1.identifier == 1))
+    <<_v::1, level::7>> = vad_extension.data
 
     rtp_timestamp = buffer.metadata.rtp.timestamp
     epoch = timestamp_epoch(state.current_timestamp, rtp_timestamp)

--- a/test/membrane/rtp/packet_test.exs
+++ b/test/membrane/rtp/packet_test.exs
@@ -49,10 +49,10 @@ defmodule Membrane.RTP.PacketTest do
   end
 
   test "reads and serializes extension header" do
-    extension_header = <<190::8, 222::8, 1::16, 1::4, 0::4, 190::8, 0::16>>
+    extension_header = <<0xBE::8, 0xDE::8, 1::16, 1::4, 0::4, 0xBE::8, 0::16>>
 
     expected_parsed_extensions = [
-      %Membrane.RTP.Header.Extension{data: <<190>>, profile_specific: 1}
+      %Membrane.RTP.Header.Extension{data: <<0xBE>>, profile_specific: 1}
     ]
 
     # Extension is stored on 4th bit of header
@@ -76,7 +76,7 @@ defmodule Membrane.RTP.PacketTest do
       Fixtures.sample_packet()
       | header: %Header{
           Fixtures.sample_header()
-          | extensions: [%Membrane.RTP.Header.Extension{data: <<190, 0>>, profile_specific: 1}]
+          | extensions: [%Membrane.RTP.Header.Extension{data: <<0xBE, 0>>, profile_specific: 1}]
         }
     }
 

--- a/test/membrane/rtp/packet_test.exs
+++ b/test/membrane/rtp/packet_test.exs
@@ -49,7 +49,7 @@ defmodule Membrane.RTP.PacketTest do
   end
 
   test "reads and serializes extension header" do
-    extension_header = <<0xBE::8, 0xDE::8, 1::16, 1::4, 0::4, 0xBE::8, 0::16>>
+    extension_header = <<0xBE, 0xDE, 1::16, 1::4, 0::4, 0xBE, 0::16>>
 
     expected_parsed_extensions = [
       %Membrane.RTP.Header.Extension{data: <<0xBE>>, identifier: 1}

--- a/test/membrane/rtp/packet_test.exs
+++ b/test/membrane/rtp/packet_test.exs
@@ -52,7 +52,7 @@ defmodule Membrane.RTP.PacketTest do
     extension_header = <<0xBE::8, 0xDE::8, 1::16, 1::4, 0::4, 0xBE::8, 0::16>>
 
     expected_parsed_extensions = [
-      %Membrane.RTP.Header.Extension{data: <<0xBE>>, profile_specific: 1}
+      %Membrane.RTP.Header.Extension{data: <<0xBE>>, identifier: 1}
     ]
 
     # Extension is stored on 4th bit of header
@@ -76,7 +76,10 @@ defmodule Membrane.RTP.PacketTest do
       Fixtures.sample_packet()
       | header: %Header{
           Fixtures.sample_header()
-          | extensions: [%Membrane.RTP.Header.Extension{data: <<0xBE, 0>>, profile_specific: 1}]
+          | extensions: [
+              %Membrane.RTP.Header.Extension{data: <<0xBE, 0>>, identifier: 1},
+              %Membrane.RTP.Header.Extension{data: <<0xDE, 0>>, identifier: 2}
+            ]
         }
     }
 

--- a/test/membrane/rtp/parser_test.exs
+++ b/test/membrane/rtp/parser_test.exs
@@ -26,7 +26,7 @@ defmodule Membrane.RTP.ParserTest do
                           payload_type: 14,
                           ssrc: 3_919_876_492,
                           csrcs: [],
-                          extension: nil,
+                          extensions: [],
                           marker: false,
                           has_padding?: false,
                           total_header_size: 12

--- a/test/membrane/rtp/session_bin_test.exs
+++ b/test/membrane/rtp/session_bin_test.exs
@@ -169,7 +169,7 @@ defmodule Membrane.RTP.Session.BinTest do
     end
 
     @impl true
-    def handle_notification({:new_rtp_stream, ssrc, pt}, :rtp, _ctx, state) do
+    def handle_notification({:new_rtp_stream, ssrc, pt, _extensions}, :rtp, _ctx, state) do
       {encoding, _clock_rate} = Map.fetch!(state.fmt_mapping, pt)
 
       depayloader =

--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -62,14 +62,16 @@ defmodule Membrane.RTP.VADTest do
 
   defp rtp_buffer(volume, timestamp) when volume in -127..0 do
     level = -volume
-    data = <<16, 1::1, level::7, 0, 0>>
+    data = <<1::1, level::7>>
 
     rtp_metadata = %{
       csrcs: [],
-      extension: %Membrane.RTP.Header.Extension{
-        data: data,
-        profile_specific: <<190, 222>>
-      },
+      extensions: [
+        %Membrane.RTP.Header.Extension{
+          data: data,
+          identifier: 1
+        }
+      ],
       has_padding?: false,
       marker: false,
       payload_type: 111,

--- a/test/support/rtp_fixtures.ex
+++ b/test/support/rtp_fixtures.ex
@@ -39,7 +39,8 @@ defmodule Membrane.RTP.Fixtures do
       payload_type: 14,
       sequence_number: 3983,
       ssrc: 3_919_876_492,
-      timestamp: 1_653_702_647
+      timestamp: 1_653_702_647,
+      extensions: []
     }
 
   @spec fake_packet_list(Range.t()) :: [binary()]


### PR DESCRIPTION
Implement the mechanism described in [RFC 8285](https://datatracker.ietf.org/doc/html/rfc8285).  Support only a one-byte header, as according to RFC this form is preferred and it must be supported by all receivers.