### PR TITLE
VAD finds timestamp in rtp metadata

### DIFF
--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -9,6 +9,13 @@ defmodule Membrane.RTP.VAD do
 
   When avg falls below `vad_threshold` and doesn't exceed it in the next `vad_silence_timer`
   it emits notification `t:silence_notification_t/0`.
+
+  Buffers that are processed by this element may or may not have been processed by
+  a depayloader and passed through a jitter buffer. If they have not, then the only timestamp
+  available for time comparison is the RTP timestamp. The delta between RTP timestamps is
+  dependent on the clock rate used by the encoding. For `OPUS` the clock rate is `48kHz` and
+  packets are sent every `20ms`, so the RTP timestamp delta between sequential packets should
+  be `48000 / 1000 * 20`, or `960`.
   """
   use Membrane.Filter
 
@@ -24,7 +31,7 @@ defmodule Membrane.RTP.VAD do
   def_options clock_rate: [
                 spec: Membrane.RTP.clock_rate_t(),
                 default: 48_000,
-                description: "Clock rate of thingy"
+                description: "Clock rate (in `Hz`) for the encoding."
               ],
               time_window: [
                 spec: pos_integer(),

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -91,7 +91,7 @@ defmodule Membrane.RTP.VAD do
     <<_id::4, _len::4, _v::1, level::7, _rest::binary-size(2)>> =
       buffer.metadata.rtp.extension.data
 
-    state = %{state | current_timestamp: buffer.metadata.timestamp}
+    state = %{state | current_timestamp: buffer.metadata.rtp.timestamp}
     state = filter_old_audio_levels(state)
     state = add_new_audio_level(state, level)
     audio_levels_vad = get_audio_levels_vad(state)

--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -92,7 +92,7 @@ defmodule Membrane.RTP.VADTest do
              } = new_state
     end
 
-    test "changes to :speech when ...", %{state: state} do
+    test "changes between :speech and :silence based on a running average", %{state: state} do
       original_timestamp = 1_201_851_607
 
       {{:ok, [buffer: _]}, state} =

--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -1,0 +1,113 @@
+defmodule Membrane.RTP.VADTest do
+  use ExUnit.Case
+
+  alias Membrane.RTP.VAD
+
+  ExUnit.Case.register_attribute(__MODULE__, :clock_rate)
+  ExUnit.Case.register_attribute(__MODULE__, :min_packet_num)
+  ExUnit.Case.register_attribute(__MODULE__, :time_window)
+  ExUnit.Case.register_attribute(__MODULE__, :vad_silence_time)
+  ExUnit.Case.register_attribute(__MODULE__, :vad_threshold)
+
+  defp get_attribute(ctx, attribute) do
+    Map.get(ctx.registered, attribute) ||
+      VAD.options()
+      |> Keyword.fetch!(attribute)
+      |> Keyword.fetch!(:default)
+  end
+
+  defp setup_vad_state(ctx) do
+    {:ok, state} =
+      VAD.handle_init(%{
+        clock_rate: get_attribute(ctx, :clock_rate),
+        min_packet_num: get_attribute(ctx, :min_packet_num),
+        time_window: get_attribute(ctx, :time_window),
+        vad_silence_time: get_attribute(ctx, :vad_silence_time),
+        vad_threshold: get_attribute(ctx, :vad_threshold)
+      })
+
+    [state: state]
+  end
+
+  defp rtp_buffer(volume, timestamp) when volume in -127..0 do
+    level = -volume
+    data = <<16, 1::1, level::7, 0, 0>>
+
+    rtp_metadata = %{
+      csrcs: [],
+      extension: %Membrane.RTP.Header.Extension{
+        data: data,
+        profile_specific: <<190, 222>>
+      },
+      has_padding?: false,
+      marker: false,
+      payload_type: 111,
+      sequence_number: 16_503,
+      ssrc: 1_464_407_876,
+      timestamp: timestamp,
+      total_header_size: 20
+    }
+
+    %Membrane.Buffer{metadata: %{rtp: rtp_metadata}, payload: <<>>}
+  end
+
+  defp iterate_for(buffers: buffer_count, volume: volume, initial: state) do
+    original_timestamp = state.current_timestamp
+    interval = 20
+    time_delta = state.clock_rate / 1000 * interval
+
+    Enum.reduce(1..buffer_count, state, fn index, state ->
+      new_timestamp = original_timestamp + time_delta * index
+      buffer = rtp_buffer(volume, new_timestamp)
+
+      {{:ok, _}, new_state} = VAD.handle_process(:input, buffer, %{}, state)
+      new_state
+    end)
+  end
+
+  describe "handle_process" do
+    setup :setup_vad_state
+
+    test "keeps running totals for buffers within a specific time window", %{state: state} do
+      buffer = rtp_buffer(-127, 1_201_851_607)
+
+      {{:ok, [buffer: _]}, new_state} = VAD.handle_process(:input, buffer, %{}, state)
+
+      assert %{
+               audio_levels_count: 1,
+               audio_levels_sum: -127,
+               current_timestamp: 1_201_851_607,
+               vad: :silence
+             } = new_state
+
+      buffer = rtp_buffer(-50, 1_201_852_567)
+
+      {{:ok, [buffer: _]}, new_state} = VAD.handle_process(:input, buffer, %{}, new_state)
+
+      assert %{
+               audio_levels_count: 2,
+               audio_levels_sum: -177,
+               current_timestamp: 1_201_852_567,
+               vad: :silence
+             } = new_state
+    end
+
+    test "changes to :speech when ...", %{state: state} do
+      original_timestamp = 1_201_851_607
+
+      {{:ok, [buffer: _]}, state} =
+        VAD.handle_process(:input, rtp_buffer(-127, original_timestamp), %{}, state)
+
+      assert %{vad: :silence} = state
+
+      new_state = iterate_for(buffers: 100, volume: 0, initial: state)
+      assert %{vad: :speech} = new_state
+
+      new_state = iterate_for(buffers: 5000, volume: 0, initial: state)
+      assert %{audio_levels_count: 101, vad: :speech} = new_state
+
+      new_state = iterate_for(buffers: 100, volume: -127, initial: state)
+      assert %{audio_levels_count: 101, vad: :silence} = new_state
+    end
+  end
+end

--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -137,6 +137,9 @@ defmodule Membrane.RTP.VADTest do
                audio_levels_sum: -177,
                vad: :silence
              } = new_state
+
+      new_state = iterate_for(buffers: 100, volume: 0, initial: new_state, time_delta: time_delta)
+      assert %{audio_levels_count: 101, audio_levels_sum: -50, vad: :speech} = new_state
     end
 
     test "changes between :speech and :silence based on a running average", ctx do


### PR DESCRIPTION
Timestamps were removed from top level metadata. When depayloaders are removed from the bin, this would blow up for us.

Co-authored-by: Austin Putman <austinp@geometer.io>
Co-authored-by: Jason Carter <jason@geometer.io>