### PR TITLE
Fixed invalid timestamps calculations inside rtp serializer

### DIFF
--- a/lib/membrane/rtp/serializer.ex
+++ b/lib/membrane/rtp/serializer.ex
@@ -68,8 +68,7 @@ defmodule Membrane.RTP.Serializer do
     {rtp_metadata, metadata} = Map.pop(metadata, :rtp, %{})
 
     rtp_offset =
-      rtp_metadata
-      |> buffer_timestamp(metadata)
+      metadata.timestamp
       |> Ratio.mult(state.clock_rate)
       |> Membrane.Time.to_seconds()
 
@@ -94,7 +93,4 @@ defmodule Membrane.RTP.Serializer do
 
     {{:ok, buffer: {:output, buffer}}, state}
   end
-
-  defp buffer_timestamp(%{timestamp: timestamp}, _metadata), do: timestamp
-  defp buffer_timestamp(_rtp_metadata, %{timestamp: timestamp}), do: timestamp
 end


### PR DESCRIPTION
During refactor of payloaders/depaylaoders it happened that for audio packets a wrong timestamp was being taken into rtp timestamp calculations. Right now when serializer is being used only for depayloaded streams it should take only `metadata` timestamps into consideration and ignore any `rtp` timestamps.

Before this change the serializer worked as expected for video as there was no rtp timestamp present so it always took the metadata one.