### PR TITLE
Fix handling of first VAD timestamp

### DIFF
--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -248,9 +248,8 @@ defmodule Membrane.RTP.VADTest do
       state = process_buffer(rtp_buffer(-5, 995), state)
       state = process_buffer(rtp_buffer(-5, 1995), state)
       state = process_buffer(rtp_buffer(-5, 2995), state)
-      state = process_buffer(rtp_buffer(-5, 3995), state)
 
-      assert %{audio_levels_count: 3, audio_levels_sum: -15, vad: :speech} = state
+      assert %{audio_levels_count: 2, audio_levels_sum: -10, vad: :silence} = state
     end
 
     test "ignore RTP packets that arrive out of order", ctx do

--- a/test/membrane/rtp/vad_test.exs
+++ b/test/membrane/rtp/vad_test.exs
@@ -28,7 +28,7 @@ defmodule Membrane.RTP.VADTest do
   end
 
   defp generate_initial_timestamp(_ctx),
-    do: [initial_timestamp: :rand.uniform(2_147_483_647)]
+    do: [initial_timestamp: :rand.uniform(4_294_967_295)]
 
   defp get_vad_attribute_or_default(ctx, attribute) do
     Map.get(ctx.registered, attribute) ||
@@ -247,8 +247,10 @@ defmodule Membrane.RTP.VADTest do
       state = process_buffer(rtp_buffer(-127, initial_timestamp + 1000), state)
       state = process_buffer(rtp_buffer(-5, 995), state)
       state = process_buffer(rtp_buffer(-5, 1995), state)
+      state = process_buffer(rtp_buffer(-5, 2995), state)
+      state = process_buffer(rtp_buffer(-5, 3995), state)
 
-      assert %{audio_levels_count: 2, audio_levels_sum: -10, vad: :silence} = state
+      assert %{audio_levels_count: 3, audio_levels_sum: -15, vad: :speech} = state
     end
 
     test "ignore RTP packets that arrive out of order", ctx do


### PR DESCRIPTION
When the initial RTP timestamp is very far from 0, it is thought to be from the previous epoch of 32bit integers
after an integer wrap around. When we do not have any saved audio levels, we know we should start processing.