### PR TITLE
Update SilenceDiscarder

### DIFF
--- a/lib/membrane/rtp/packet.ex
+++ b/lib/membrane/rtp/packet.ex
@@ -3,8 +3,8 @@ defmodule Membrane.RTP.Packet do
   Defines a struct describing an RTP packet and a way to parse and serialize it.
   Based on [RFC3550](https://tools.ietf.org/html/rfc3550#page-13)
 
-  Support only one-byte header from [RFC8285](https://www.rfc-editor.org/rfc/pdfrfc/rfc8285.txt.pdf), as according to document
-  this form is preferred and it must be supported by all receivers.
+  Supports only one-byte header from [RFC8285](https://datatracker.ietf.org/doc/html/rfc8285#section-4.2),
+  as according to the document this form is preferred and it must be supported by all receivers.
   """
 
   alias Membrane.RTP.{Header, Utils}

--- a/lib/membrane/rtp/serializer.ex
+++ b/lib/membrane/rtp/serializer.ex
@@ -4,7 +4,7 @@ defmodule Membrane.RTP.Serializer do
   incrementing timestamps and sequence numbers for each packet. Header information then is put
   inside buffer's metadata under `:rtp` key.
 
-  Accepts the following metadata under `:rtp` key: `:marker`, `:csrcs`, `:extension`.
+  Accepts the following metadata under `:rtp` key: `:marker`, `:csrcs`, `:extensions`.
   See `Membrane.RTP.Header` for their meaning and specifications.
   """
   use Membrane.Filter

--- a/lib/membrane/rtp/silence_discarder.ex
+++ b/lib/membrane/rtp/silence_discarder.ex
@@ -2,8 +2,8 @@ defmodule Membrane.RTP.SilenceDiscarder do
   @moduledoc """
   Element responsible for dropping silent audio packets.
 
-  For a packet to be discarded it needs to contain a `RTP.Header.Extension` struct in its
-  metadata under `:rtp` key. The header should contain information about audio level (VAD extension is required).
+  For a packet to be discarded it needs to contain a `RTP.Header.Extension` struct with identifier equal to `vad_id` in
+  its extensions list. The header extension will contain information about audio level (VAD extension is required).
   The element will only drop packets whose audio level is above given silence threshold (muted audio is of value 127).
 
   `#{__MODULE__}` will drop as many silent packets as possible and on reaching dropping limit it will send the current buffer,


### PR DESCRIPTION
- adjusted `RTP.SilenceDiscarder` to the recent changes in RTP header extensions
- added `RTP.Header.Extension.find/2`
- updated moduledocs mentioning header extensions
- changed defaults in `RTP.SilenceDiscarder` options

Default for `silence_threshold` has been changed to quite arbitrary `64`, as this value seems to do pretty well. Previously set `127` was too strict to ever drop any packet 🤔  