### PR TITLE
Bandwith estimation

### DIFF
--- a/lib/membrane/rtcp/parser.ex
+++ b/lib/membrane/rtcp/parser.ex
@@ -65,6 +65,13 @@ defmodule Membrane.RTCP.Parser do
     []
   end
 
+  defp process_rtcp(
+         %RTCP.TransportFeedbackPacket{payload: %RTCP.TransportFeedbackPacket.TWCC{} = feedback},
+         _metadata
+       ) do
+    [notify: {:twcc_feedback, feedback}]
+  end
+
   defp process_rtcp(%RTCP.SenderReportPacket{ssrc: ssrc} = packet, metadata) do
     event = %RTCPEvent{
       rtcp: packet,

--- a/lib/membrane/rtcp/transport_feedback_packet/twcc.ex
+++ b/lib/membrane/rtcp/transport_feedback_packet/twcc.ex
@@ -28,7 +28,7 @@ defmodule Membrane.RTCP.TransportFeedbackPacket.TWCC do
     :feedback_packet_count
   ]
 
-  @type t :: %{
+  @type t :: %__MODULE__{
           base_seq_num: non_neg_integer(),
           reference_time: Time.t(),
           packet_status_count: pos_integer(),
@@ -186,7 +186,7 @@ defmodule Membrane.RTCP.TransportFeedbackPacket.TWCC do
          [:small_delta | rest_status],
          parsed_deltas
        ) do
-    parse_receive_deltas(rest, rest_status, [Time.microseconds(delta) * 250 | parsed_deltas])
+    parse_receive_deltas(rest, rest_status, [Time.microseconds(delta * 250) | parsed_deltas])
   end
 
   defp parse_receive_deltas(
@@ -194,7 +194,7 @@ defmodule Membrane.RTCP.TransportFeedbackPacket.TWCC do
          [:large_or_negative_delta | rest_status],
          parsed_deltas
        ) do
-    parse_receive_deltas(rest, rest_status, [Time.microseconds(delta) * 250 | parsed_deltas])
+    parse_receive_deltas(rest, rest_status, [Time.microseconds(delta * 250) | parsed_deltas])
   end
 
   defp parse_receive_deltas(_payload, [:reserved | _rest_status], _parsed_deltas),

--- a/lib/membrane/rtp/session_bin.ex
+++ b/lib/membrane/rtp/session_bin.ex
@@ -579,7 +579,7 @@ defmodule Membrane.RTP.SessionBin do
 
   @impl true
   def handle_notification({:bandwidth_estimation, val}, :twcc_sender, _ctx, state) do
-    Membrane.Logger.error("Received bandwidth estimation: " <> inspect(val / 1000) <> "kbps")
+    Membrane.Logger.info("Received bandwidth estimation: " <> inspect(val / 1000) <> "kbps")
     {:ok, state}
   end
 
@@ -658,8 +658,7 @@ defmodule Membrane.RTP.SessionBin do
     # Workaround: as TWCC is a transport-wide extension, there should exist only one TWCC sender
     # child that handles packets for all outgoing streams. As there is no support for declaring
     # outbound extensions, outbound TWCC will be enabled if inbound TWCC has been enabled.
-    # Map.has_key?(ctx.children, :twcc_receiver)
-    should_link? = true
+    should_link? = Map.has_key?(ctx.children, :twcc_receiver)
     should_create_child? = not Map.has_key?(ctx.children, :twcc_sender)
 
     if should_link? do

--- a/lib/membrane/rtp/session_bin.ex
+++ b/lib/membrane/rtp/session_bin.ex
@@ -577,6 +577,12 @@ defmodule Membrane.RTP.SessionBin do
     {{:ok, forward: {:twcc_sender, msg}}, state}
   end
 
+  @impl true
+  def handle_notification({:bandwidth_estimation, val}, :twcc_sender, _ctx, state) do
+    Membrane.Logger.error("Received bandwidth estimation: " <> inspect(val / 1000) <> "kbps")
+    {:ok, state}
+  end
+
   defp add_ssrc(remote_ssrc, state) do
     %{ssrcs: ssrcs, receiver_ssrc_generator: generator} = state
     local_ssrc = generator.([remote_ssrc | Map.keys(ssrcs)], Map.values(ssrcs))

--- a/lib/membrane/rtp/session_bin.ex
+++ b/lib/membrane/rtp/session_bin.ex
@@ -573,14 +573,13 @@ defmodule Membrane.RTP.SessionBin do
   end
 
   @impl true
-  def handle_notification({:twcc_feedback, _feedback} = msg, _rtcp_parser, _ctx, state) do
-    {{:ok, forward: {:twcc_sender, msg}}, state}
+  def handle_notification({:bandwidth_estimation, _val} = msg, :twcc_sender, _ctx, state) do
+    {{:ok, notify: msg}, state}
   end
 
   @impl true
-  def handle_notification({:bandwidth_estimation, val}, :twcc_sender, _ctx, state) do
-    Membrane.Logger.info("Received bandwidth estimation: " <> inspect(val / 1000) <> "kbps")
-    {:ok, state}
+  def handle_notification({:twcc_feedback, _feedback} = msg, _rtcp_parser, _ctx, state) do
+    {{:ok, forward: {:twcc_sender, msg}}, state}
   end
 
   defp add_ssrc(remote_ssrc, state) do

--- a/lib/membrane/rtp/session_bin.ex
+++ b/lib/membrane/rtp/session_bin.ex
@@ -572,6 +572,11 @@ defmodule Membrane.RTP.SessionBin do
     {{:ok, notify: msg}, state}
   end
 
+  @impl true
+  def handle_notification({:twcc_feedback, _feedback} = msg, _rtcp_parser, _ctx, state) do
+    {{:ok, forward: {:twcc_sender, msg}}, state}
+  end
+
   defp add_ssrc(remote_ssrc, state) do
     %{ssrcs: ssrcs, receiver_ssrc_generator: generator} = state
     local_ssrc = generator.([remote_ssrc | Map.keys(ssrcs)], Map.values(ssrcs))
@@ -647,7 +652,8 @@ defmodule Membrane.RTP.SessionBin do
     # Workaround: as TWCC is a transport-wide extension, there should exist only one TWCC sender
     # child that handles packets for all outgoing streams. As there is no support for declaring
     # outbound extensions, outbound TWCC will be enabled if inbound TWCC has been enabled.
-    should_link? = Map.has_key?(ctx.children, :twcc_receiver)
+    # Map.has_key?(ctx.children, :twcc_receiver)
+    should_link? = true
     should_create_child? = not Map.has_key?(ctx.children, :twcc_sender)
 
     if should_link? do

--- a/lib/membrane/rtp/twcc_receiver.ex
+++ b/lib/membrane/rtp/twcc_receiver.ex
@@ -35,6 +35,7 @@ defmodule Membrane.RTP.TWCCReceiver do
 
   defmodule State do
     @moduledoc false
+    use Bunch.Access
     alias Membrane.RTP.TWCCReceiver.PacketInfoStore
 
     @type t :: %__MODULE__{

--- a/lib/membrane/rtp/twcc_receiver.ex
+++ b/lib/membrane/rtp/twcc_receiver.ex
@@ -35,7 +35,6 @@ defmodule Membrane.RTP.TWCCReceiver do
 
   defmodule State do
     @moduledoc false
-    use Bunch.Access
     alias Membrane.RTP.TWCCReceiver.PacketInfoStore
 
     @type t :: %__MODULE__{

--- a/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
+++ b/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
@@ -105,18 +105,17 @@ defmodule Membrane.RTP.TWCCReceiver.PacketInfoStore do
 
     receive_deltas =
       base_seq_num..max_seq_num
-      |> Enum.reduce({[], reference_time}, fn seq_num, {deltas, previous_timestamp} ->
+      |> Enum.map_reduce(reference_time, fn seq_num, previous_timestamp ->
         case Map.get(seq_to_timestamp, seq_num) do
           nil ->
-            {[:not_received | deltas], previous_timestamp}
+            {:not_received, previous_timestamp}
 
           timestamp ->
             delta = timestamp - previous_timestamp
-            {[delta | deltas], timestamp}
+            {delta, timestamp}
         end
       end)
       |> elem(0)
-      |> Enum.reverse()
 
     {reference_time, receive_deltas}
   end

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -26,9 +26,15 @@ defmodule Membrane.RTP.TWCCSender do
        seq_to_delta: %{},
        seq_to_size: %{},
        cc: %CongestionControl{},
-       bandwidth_report_interval: Time.seconds(2)
+       bandwidth_report_interval: Time.seconds(5)
      }}
   end
+
+  @impl true
+  def handle_pad_added(_pad, _ctx, state), do: {:ok, %{state | cc: %CongestionControl{}}}
+
+  @impl true
+  def handle_pad_removed(_pad, _ctx, state), do: {:ok, %{state | cc: %CongestionControl{}}}
 
   @impl true
   def handle_caps(Pad.ref(:input, id), caps, _ctx, state) do

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -34,9 +34,8 @@ defmodule Membrane.RTP.TWCCSender do
     {{:ok, event: {Pad.ref(opposite_direction, id), event}}, state}
   end
 
+  @impl true
   def handle_other({:twcc_feedback, feedback}, _ctx, state) do
-    # Membrane.Logger.error("got feedback: " <> inspect(feedback))
-
     %TWCC{
       base_seq_num: base_seq_num,
       feedback_packet_count: feedback_packet_count,
@@ -44,24 +43,6 @@ defmodule Membrane.RTP.TWCCSender do
       receive_deltas: receive_deltas,
       reference_time: reference_time
     } = feedback
-
-    # notr = Enum.count(receive_deltas, fn delta -> delta == :not_received end)
-
-    # ld =
-    #   Enum.filter(receive_deltas, fn delta -> delta != :not_received end)
-    #   |> Enum.count(fn delta -> Time.to_milliseconds(delta) > 64 end)
-
-    # ng =
-    #   Enum.filter(receive_deltas, fn delta -> delta != :not_received end)
-    #   |> Enum.count(fn delta -> Time.to_milliseconds(delta) < 0 end)
-
-    # if Enum.any?([notr, ld, ng], fn n -> n > 0 end) do
-    #   Membrane.Logger.error("----------------------------------------------------------------")
-    #   Membrane.Logger.error("not_r: " <> inspect(notr * 100 / length(receive_deltas)) <> "%")
-    #   Membrane.Logger.error("large: " <> inspect(ld * 100 / length(receive_deltas)) <> "%")
-    #   Membrane.Logger.error("negat: " <> inspect(ng * 100 / length(receive_deltas)) <> "%")
-    #   Membrane.Logger.error("----------------------------------------------------------------")
-    # end
 
     max_seq_num = base_seq_num + packet_count - 1
 
@@ -82,6 +63,7 @@ defmodule Membrane.RTP.TWCCSender do
     Membrane.Logger.error("A_hat: " <> inspect(cc.a_hat / 1000) <> "kbps")
     # Membrane.Logger.error("As_hat: " <> inspect(cc.as_hat / 1000) <> "kbps")
     Membrane.Logger.error("state: " <> inspect(cc.state))
+    # Membrane.Logger.error(inspect(cc))
 
     {:ok, %{state | cc: cc}}
   end

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -11,7 +11,6 @@ defmodule Membrane.RTP.TWCCSender do
   alias __MODULE__.CongestionControl
 
   require Bitwise
-  require Membrane.Logger
 
   @seq_number_limit Bitwise.bsl(1, 16)
 

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -83,7 +83,7 @@ defmodule Membrane.RTP.TWCCSender do
     max_seq_num = base_seq_num + packet_count - 1
 
     rtt =
-      Time.monotonic_time() -
+      Time.vm_time() -
         Map.fetch!(state.seq_to_timestamp, rem(max_seq_num, @seq_number_limit))
 
     sequence_numbers = Enum.map(base_seq_num..max_seq_num, &rem(&1, @seq_number_limit))
@@ -125,7 +125,7 @@ defmodule Membrane.RTP.TWCCSender do
 
     state =
       state
-      |> put_in([:seq_to_timestamp, seq_num], Time.monotonic_time())
+      |> put_in([:seq_to_timestamp, seq_num], Time.vm_time())
       |> put_in([:seq_to_size, seq_num], bit_size(buffer.payload))
 
     out_pad = Pad.ref(:output, id)

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -45,7 +45,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     # timestamp indicating when we started to underuse the link
     underuse_start_ts: nil,
     # latest timestamp indicating when the receiver-side bandwidth was increased
-    last_bandwidth_increase_ts: Time.monotonic_time(),
+    last_bandwidth_increase_ts: Time.vm_time(),
     # receiver-side bandwidth estimation in bps
     a_hat: 300_000.0,
     # sender-side bandwidth estimation in bps
@@ -187,7 +187,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
   defp make_signal(%__MODULE__{m_hat: m_hat, del_var_th: del_var_th} = cc, prev_m_hat)
        when m_hat < -del_var_th do
-    now = Time.monotonic_time()
+    now = Time.vm_time()
 
     underuse_start_ts = cc.underuse_start_ts || now
 
@@ -203,7 +203,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
   defp make_signal(%__MODULE__{m_hat: m_hat, del_var_th: del_var_th} = cc, prev_m_hat)
        when m_hat > del_var_th do
-    now = Time.monotonic_time()
+    now = Time.vm_time()
 
     overuse_start_ts = cc.overuse_start_ts || now
 
@@ -306,7 +306,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
     r_hat = 1 / (packet_received_interval_ms / 1000) * packet_received_sizes
 
-    now = Time.monotonic_time()
+    now = Time.vm_time()
     last_bandwidth_increase_ts = last_bandwidth_increase_ts || now
     time_since_last_update_ms = Time.to_milliseconds(now - last_bandwidth_increase_ts)
 

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -208,7 +208,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
     underuse_start_ts = cc.underuse_start_ts || now
 
-    trigger_underuse? = now - underuse_start_ts > cc.signal_time_threshold and m_hat <= prev_m_hat
+    trigger_underuse? =
+      now - underuse_start_ts >= cc.signal_time_threshold and m_hat <= prev_m_hat
 
     if trigger_underuse? do
       {:underuse, %__MODULE__{cc | underuse_start_ts: now, overuse_start_ts: nil}}
@@ -223,7 +224,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
     overuse_start_ts = cc.overuse_start_ts || now
 
-    trigger_overuse? = now - overuse_start_ts > cc.signal_time_threshold and m_hat >= prev_m_hat
+    trigger_overuse? = now - overuse_start_ts >= cc.signal_time_threshold and m_hat >= prev_m_hat
 
     if trigger_overuse? do
       {:overuse, %__MODULE__{cc | underuse_start_ts: nil, overuse_start_ts: now}}

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -19,22 +19,23 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
   @coeff_K_d 0.00018
 
   # T: Time window for measuring the received bitrate (in ms), between [0.5, 1] s
-  @last_packet_interval 1000
+  @last_packet_interval_ms 1000
 
   # alpha factor for exponential moving average
-  @ema_alpha_factor 0.95
+  @ema_smoothing_factor 0.95
+
+  # time required to trigger a signal, 10ms ("overuse_time_th" in RFC)
+  @signal_time_threshold 10.0
 
   defstruct [
-    # inter-group mean delay estimate (in ms)
-    m_hat: 0,
+    # inter-group delay estimate (in ms)
+    m_hat: 0.0,
     # system error covariance
     e: 0.1,
     # estimate for the state noise variance
-    var_v_hat: 0,
+    var_v_hat: 0.0,
     # initial value for the adaptive threshold, 12.5ms
     del_var_th: 12.5,
-    # time required to trigger a signal, 10ms
-    signal_time_th: 10,
     # last rates at which packets were received
     last_rates: [],
     # current delay-based controller state
@@ -45,16 +46,26 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     underuse_start_ts: nil,
     # latest timestamp indicating when the receiver-side bandwidth was updated
     last_bandwidth_update_ts: nil,
-    # receiver-side bandwidth estimation
-    a_hat: 0,
-    # sender-side bandwidth estimation
-    as_hat: 0,
+    # receiver-side bandwidth estimation, initialized as 300kbps
+    a_hat: 100_000_000.0,
+    # sender-side bandwidth estimation, initialized as 300kbps
+    as_hat: 100_000_000.0,
     # latest estimates of receiver-side bandwidth
     r_hats: [],
+    # accumulator for packet sizes that have been received through @last_packet_interval_ms
+    last_packet_received_sizes: 0,
+    last_packet_received_interval_start: nil,
+    last_packet_received_interval_end: nil,
     debug_interarrival: []
   ]
 
-  def update(cc, receive_deltas, send_deltas, packet_sizes) do
+  def update(
+        %__MODULE__{m_hat: prev_m_hat} = cc,
+        reference_time,
+        receive_deltas,
+        send_deltas,
+        packet_sizes
+      ) do
     receive_deltas =
       Enum.map(receive_deltas, fn delta ->
         if delta == :not_received, do: delta, else: Time.to_milliseconds(delta)
@@ -62,136 +73,55 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
     send_deltas = Enum.map(send_deltas, &Time.to_milliseconds/1)
 
-    Enum.zip_reduce(receive_deltas, send_deltas, cc, fn recv_delta, send_delta, cc ->
-      do_update(cc, recv_delta, send_delta)
-    end)
-    |> update_bandwidth(receive_deltas, packet_sizes)
-    |> update_loss(receive_deltas)
-    |> tap(
-      &Membrane.Logger.error(
-        "avg_interarrival: " <>
-          inspect(Enum.sum(&1.debug_interarrival) / length(&1.debug_interarrival))
-      )
-    )
-  end
-
-  defp update_loss(%__MODULE__{as_hat: as_hat} = cc, receive_deltas) do
-    loss = Enum.count(receive_deltas, &(&1 == :not_received))
-    loss_ratio = loss / length(receive_deltas)
-
-    as_hat =
-      cond do
-        loss_ratio < 0.02 -> 1.05 * as_hat
-        loss_ratio > 0.1 -> as_hat * (1 - 0.5 * loss_ratio)
-        true -> as_hat
-      end
-
-    %__MODULE__{as_hat: as_hat}
-  end
-
-  defp do_update(%__MODULE__{m_hat: prev_m_hat} = cc, recv_delta, send_delta) do
     cc
-    |> update_metrics(recv_delta, send_delta)
+    |> update_metrics(receive_deltas, send_deltas)
     |> make_signal(prev_m_hat)
-    |> then(fn {signal, cc} -> update_state(cc, signal) end)
+    |> then(fn {signal, cc} ->
+      Membrane.Logger.error(inspect(signal))
+      update_state(cc, signal)
+    end)
+    |> store_packet_received_sizes(reference_time, receive_deltas, packet_sizes)
+    |> maybe_increase_bandwidth(packet_sizes)
+    |> update_loss(receive_deltas)
   end
 
-  defp update_bandwidth(cc, receive_deltas, packet_sizes) do
-    %__MODULE__{
-      r_hats: r_hats,
-      a_hat: prev_a_hat,
-      last_bandwidth_update_ts: last_bandwidth_update_ts
-    } = cc
+  defp update_metrics(cc, [], []), do: cc
 
-    total_size =
-      Enum.reverse(receive_deltas)
-      |> Enum.zip(Enum.reverse(packet_sizes))
-      |> Enum.reduce_while({0, 0}, fn {recv_delta, packet_size}, {time, total_size} ->
-        cond do
-          recv_delta == :not_received or recv_delta < 0 ->
-            {:cont, {time, total_size}}
+  defp update_metrics(cc, [:not_received | recv_deltas], [send_delta | send_deltas]) do
+    case {recv_deltas, send_deltas} do
+      {[], []} ->
+        cc
 
-          recv_delta + time <= @last_packet_interval ->
-            {:cont, {time + recv_delta, total_size + packet_size}}
-
-          true ->
-            {:halt, {time, total_size}}
-        end
-      end)
-      |> then(&elem(&1, 1))
-
-    r_hat = 1 / @last_packet_interval * total_size
-
-    now = Time.monotonic_time()
-    last_bandwidth_update_ts = last_bandwidth_update_ts || now
-
-    bandwidth_update_delta =
-      Time.to_milliseconds(Time.monotonic_time() - last_bandwidth_update_ts)
-
-    a_hat =
-      case bitrate_mode(r_hat, cc) do
-        :multiplicative ->
-          eta = :math.pow(1.08, min(bandwidth_update_delta, 1))
-          eta * prev_a_hat
-
-        :additive ->
-          # rtt
-          response_time_ms = 100 + 30
-          alpha = 0.5 * min(bandwidth_update_delta / response_time_ms, 1)
-          bits_per_frame = prev_a_hat / 30
-          packets_per_frame = ceil(bits_per_frame / (1200 * 8))
-          expected_packet_size_bits = bits_per_frame / packets_per_frame
-          prev_a_hat + max(1000, alpha * expected_packet_size_bits)
-      end
-
-    a_hat = if a_hat < 1.5 * r_hat, do: @beta * r_hat, else: a_hat
-
-    %__MODULE__{
-      cc
-      | a_hat: a_hat,
-        r_hats: [r_hat | r_hats]
-    }
-  end
-
-  defp exponential_moving_average(_alpha, []), do: 0
-
-  defp exponential_moving_average(alpha, [latest_observation | older_observations]) do
-    alpha * latest_observation +
-      (1 - alpha) * exponential_moving_average(alpha, older_observations)
-  end
-
-  defp std_dev(observations) do
-    mean = Enum.sum(observations) / length(observations)
-
-    observations
-    |> Enum.map(fn obs -> (obs - mean) * (obs - mean) end)
-    |> then(&(&1 / length(observations)))
-    |> :math.sqrt()
-  end
-
-  defp bitrate_mode(r_hat, cc) do
-    exp_average = exponential_moving_average(@ema_alpha_factor, cc.r_hats)
-    std_dev = std_dev(cc.r_hats)
-
-    if r_hat > exp_average + 3 * std_dev do
-      :multiplicative
-    else
-      :additive
+      {_recv_deltas, [next_send_delta | other_send_deltas]} ->
+        update_metrics(cc, recv_deltas, [send_delta + next_send_delta | other_send_deltas])
     end
   end
 
-  defp update_metrics(cc, :not_received, _send_delta), do: cc
+  defp update_metrics(cc, [recv_delta | recv_deltas], [send_delta | send_deltas])
+       when recv_delta < 0 do
+    case {recv_deltas, send_deltas} do
+      {[], []} ->
+        cc
 
-  defp update_metrics(cc, recv_delta, _send_delta) when recv_delta < 0, do: cc
+      {[:not_received | other_recv_deltas], [next_send_delta | other_send_deltas]} ->
+        update_metrics(cc, [recv_delta | other_recv_deltas], [
+          send_delta + next_send_delta | other_send_deltas
+        ])
 
-  defp update_metrics(cc, recv_delta, send_delta) do
+      {[next_recv_delta | other_recv_deltas], [next_send_delta | other_send_deltas]} ->
+        update_metrics(cc, [recv_delta + next_recv_delta | other_recv_deltas], [
+          send_delta + next_send_delta | other_send_deltas
+        ])
+    end
+  end
+
+  defp update_metrics(cc, [recv_delta | recv_deltas], [send_delta | send_deltas]) do
     %__MODULE__{
       m_hat: prev_m_hat,
       e: e,
       var_v_hat: var_v_hat,
       del_var_th: del_var_th,
-      last_rates: last_rates,
-      debug_interarrival: debug_interarrival
+      last_rates: last_rates
     } = cc
 
     interpacket_delta = recv_delta - send_delta
@@ -224,56 +154,82 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
         del_var_th
       end
 
-    %__MODULE__{
+    cc = %__MODULE__{
       cc
       | m_hat: m_hat,
         var_v_hat: var_v_hat,
         e: e,
-        last_rates: Enum.take(last_rates, 10),
-        del_var_th: del_var_th,
-        debug_interarrival: Enum.take([interpacket_delta | debug_interarrival], 1000)
+        last_rates: Enum.take(last_rates, 100),
+        del_var_th: del_var_th
     }
+
+    update_metrics(cc, recv_deltas, send_deltas)
   end
 
   defp make_signal(cc, prev_m_hat) do
     now = Time.monotonic_time()
-    underuse_start_ts = cc.underuse_start_ts || now
-    overuse_start_ts = cc.overuse_start_ts || now
 
-    trigger_underuse? =
-      Time.to_milliseconds(now - underuse_start_ts) > cc.signal_time_th and cc.m_hat <= prev_m_hat
-
-    trigger_overuse? =
-      Time.to_milliseconds(now - overuse_start_ts) > cc.signal_time_th and cc.m_hat >= prev_m_hat
+    %__MODULE__{
+      m_hat: m_hat,
+      del_var_th: del_var_th,
+      underuse_start_ts: underuse_start_ts,
+      overuse_start_ts: overuse_start_ts
+    } = cc
 
     cond do
-      cc.m_hat < -cc.del_var_th and trigger_underuse? ->
-        {:underuse, %__MODULE__{cc | underuse_start_ts: now, overuse_start_ts: nil}}
+      m_hat < -del_var_th ->
+        underuse_start_ts = underuse_start_ts || now
 
-      cc.m_hat < -cc.del_var_th ->
-        {:normal, %__MODULE__{cc | underuse_start_ts: underuse_start_ts, overuse_start_ts: nil}}
+        trigger_underuse? =
+          Time.to_milliseconds(now - underuse_start_ts) > @signal_time_threshold and
+            m_hat <= prev_m_hat
 
-      cc.m_hat > cc.del_var_th and trigger_overuse? ->
-        {:overuse, %__MODULE__{cc | overuse_start_ts: now, underuse_start_ts: nil}}
+        if trigger_underuse?,
+          do: {:underuse, %__MODULE__{cc | underuse_start_ts: now, overuse_start_ts: nil}},
+          else:
+            {:no_signal,
+             %__MODULE__{cc | underuse_start_ts: underuse_start_ts, overuse_start_ts: nil}}
 
-      cc.m_hat > cc.del_var_th ->
-        {:normal, %__MODULE__{cc | overuse_start_ts: overuse_start_ts, underuse_start_ts: nil}}
+      m_hat > del_var_th ->
+        overuse_start_ts = overuse_start_ts || now
+
+        trigger_overuse? =
+          Time.to_milliseconds(now - overuse_start_ts) > @signal_time_threshold and
+            m_hat >= prev_m_hat
+
+        if trigger_overuse?,
+          do: {:overuse, %__MODULE__{cc | underuse_start_ts: nil, overuse_start_ts: now}},
+          else:
+            {:no_signal,
+             %__MODULE__{cc | underuse_start_ts: nil, overuse_start_ts: overuse_start_ts}}
 
       true ->
-        {:normal, %__MODULE__{cc | overuse_start_ts: nil, underuse_start_ts: nil}}
+        {:normal, %__MODULE__{cc | underuse_start_ts: nil, overuse_start_ts: nil}}
     end
   end
+
+  # +----+--------+-----------+------------+--------+
+  # |     \ State |   Hold    |  Increase  |Decrease|
+  # |      \      |           |            |        |
+  # | Signal\     |           |            |        |
+  # +--------+----+-----------+------------+--------+
+  # |  Over-use   | Decrease  |  Decrease  |        |
+  # +-------------+-----------+------------+--------+
+  # |  Normal     | Increase  |            |  Hold  |
+  # +-------------+-----------+------------+--------+
+  # |  Under-use  |           |   Hold     |  Hold  |
+  # +-------------+-----------+------------+--------+
 
   defp update_state(cc, signal)
 
   defp update_state(%__MODULE__{state: :hold} = cc, :overuse),
-    do: %__MODULE__{cc | state: :decrease}
+    do: %__MODULE__{cc | state: :decrease, a_hat: @beta * cc.a_hat}
 
   defp update_state(%__MODULE__{state: :hold} = cc, :normal),
     do: %__MODULE__{cc | state: :increase}
 
   defp update_state(%__MODULE__{state: :increase} = cc, :overuse),
-    do: %__MODULE__{cc | state: :decrease}
+    do: %__MODULE__{cc | state: :decrease, a_hat: @beta * cc.a_hat}
 
   defp update_state(%__MODULE__{state: :increase} = cc, :underuse),
     do: %__MODULE__{cc | state: :hold}
@@ -285,4 +241,134 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     do: %__MODULE__{cc | state: :hold}
 
   defp update_state(cc, _signal), do: cc
+
+  defp store_packet_received_sizes(cc, reference_time, receive_deltas, packet_sizes) do
+    %__MODULE__{
+      last_packet_received_interval_start: last_packet_received_interval_start,
+      last_packet_received_interval_end: last_packet_received_interval_end,
+      last_packet_received_sizes: last_packet_received_sizes
+    } = cc
+
+    {receive_deltas, packet_sizes} =
+      receive_deltas
+      |> Enum.zip(packet_sizes)
+      |> Enum.filter(fn {delta, _size} -> delta != :not_received end)
+      |> Enum.unzip()
+
+    time_received = Enum.scan(receive_deltas, &(&1 + &2))
+    latest_packet = Enum.max(time_received)
+    total_size = Enum.sum(packet_sizes)
+
+    %__MODULE__{
+      cc
+      | last_packet_received_interval_start:
+          last_packet_received_interval_start || reference_time,
+        last_packet_received_interval_end:
+          (last_packet_received_interval_end || reference_time) + Time.milliseconds(latest_packet),
+        last_packet_received_sizes: last_packet_received_sizes + total_size
+    }
+  end
+
+  defp maybe_increase_bandwidth(%__MODULE__{state: :increase} = cc, packet_sizes) do
+    %__MODULE__{
+      r_hats: r_hats,
+      a_hat: prev_a_hat,
+      last_bandwidth_update_ts: last_bandwidth_update_ts,
+      last_packet_received_interval_end: last_packet_received_interval_end,
+      last_packet_received_interval_start: last_packet_received_interval_start,
+      last_packet_received_sizes: last_packet_received_sizes
+    } = cc
+
+    interval =
+      Time.to_milliseconds(
+        last_packet_received_interval_end - last_packet_received_interval_start
+      )
+
+    if interval >= @last_packet_interval_ms do
+      r_hat = 1 / (interval / 1000) * last_packet_received_sizes
+
+      now = Time.monotonic_time()
+      last_bandwidth_update_ts = last_bandwidth_update_ts || now
+      time_since_last_update_ms = now - last_bandwidth_update_ts
+
+      a_hat =
+        case bitrate_mode(r_hat, cc) do
+          :multiplicative ->
+            eta = :math.pow(1.08, min(time_since_last_update_ms / 1000, 1))
+            eta * prev_a_hat
+
+          :additive ->
+            # TODO: calculate rtt
+            rtt = 30
+            response_time_ms = 100 + rtt
+            alpha = 0.5 * min(time_since_last_update_ms / response_time_ms, 1)
+            expected_packet_size_bits = Enum.sum(packet_sizes) / length(packet_sizes)
+            prev_a_hat + max(1000, alpha * expected_packet_size_bits)
+        end
+
+      a_hat = min(1.5 * r_hat, a_hat)
+
+      %__MODULE__{
+        cc
+        | a_hat: a_hat,
+          r_hats: Enum.take([r_hat | r_hats], 10),
+          last_bandwidth_update_ts: now,
+          last_packet_received_interval_end: nil,
+          last_packet_received_interval_start: nil,
+          last_packet_received_sizes: 0
+      }
+    else
+      cc
+    end
+  end
+
+  defp maybe_increase_bandwidth(cc, _packet_sizes), do: cc
+
+  defp update_loss(%__MODULE__{as_hat: as_hat} = cc, receive_deltas) do
+    lost = Enum.count(receive_deltas, &(&1 == :not_received))
+    loss_ratio = lost / length(receive_deltas)
+
+    as_hat =
+      cond do
+        loss_ratio < 0.02 -> 1.05 * as_hat
+        loss_ratio > 0.1 -> as_hat * (1 - 0.5 * loss_ratio)
+        true -> as_hat
+      end
+
+    # cap to 1Gbps
+    as_hat = min(as_hat, 1_000_000_000)
+
+    %__MODULE__{cc | as_hat: as_hat}
+  end
+
+  defp bitrate_mode(_r_hat, %__MODULE__{r_hats: prev_r_hats}) when length(prev_r_hats) < 2,
+    do: :multiplicative
+
+  defp bitrate_mode(r_hat, %__MODULE__{r_hats: prev_r_hats}) do
+    exp_average = exponential_moving_average(@ema_smoothing_factor, prev_r_hats)
+    std_dev = std_dev(prev_r_hats)
+
+    if r_hat > exp_average + 3 * std_dev do
+      :multiplicative
+    else
+      :additive
+    end
+  end
+
+  defp exponential_moving_average(_alpha, []), do: 0
+
+  defp exponential_moving_average(alpha, [latest_observation | older_observations]) do
+    alpha * latest_observation +
+      (1 - alpha) * exponential_moving_average(alpha, older_observations)
+  end
+
+  defp std_dev(observations) when observations != [] do
+    n_obs = length(observations)
+    mean = Enum.sum(observations) / n_obs
+
+    observations
+    |> Enum.reduce(0, fn obs, acc -> acc + (obs - mean) * (obs - mean) end)
+    |> then(&(&1 / n_obs))
+    |> :math.sqrt()
+  end
 end

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -1,0 +1,288 @@
+defmodule Membrane.RTP.TWCCSender.CongestionControl do
+  @moduledoc """
+  The module implements [Google congestion control algorithm](https://datatracker.ietf.org/doc/html/draft-ietf-rmcat-gcc-02).
+  """
+  alias Membrane.Time
+
+  require Membrane.Logger
+
+  # state noise covariance
+  @q 0.001
+  # filter coefficient for the measured noise variance, between [0.1, 0.001]
+  @chi 0.01
+
+  # decrease rate factor
+  @beta 0.85
+
+  # coefficients for the adaptive threshold
+  @coeff_K_u 0.01
+  @coeff_K_d 0.00018
+
+  # T: Time window for measuring the received bitrate (in ms), between [0.5, 1] s
+  @last_packet_interval 1000
+
+  # alpha factor for exponential moving average
+  @ema_alpha_factor 0.95
+
+  defstruct [
+    # inter-group mean delay estimate (in ms)
+    m_hat: 0,
+    # system error covariance
+    e: 0.1,
+    # estimate for the state noise variance
+    var_v_hat: 0,
+    # initial value for the adaptive threshold, 12.5ms
+    del_var_th: 12.5,
+    # time required to trigger a signal, 10ms
+    signal_time_th: 10,
+    # last rates at which packets were received
+    last_rates: [],
+    # current delay-based controller state
+    state: :increase,
+    # timestamp indicating when we started to overusing the link
+    overuse_start_ts: nil,
+    # timestamp indicating when we started to underusing the link
+    underuse_start_ts: nil,
+    # latest timestamp indicating when the receiver-side bandwidth was updated
+    last_bandwidth_update_ts: nil,
+    # receiver-side bandwidth estimation
+    a_hat: 0,
+    # sender-side bandwidth estimation
+    as_hat: 0,
+    # latest estimates of receiver-side bandwidth
+    r_hats: [],
+    debug_interarrival: []
+  ]
+
+  def update(cc, receive_deltas, send_deltas, packet_sizes) do
+    receive_deltas =
+      Enum.map(receive_deltas, fn delta ->
+        if delta == :not_received, do: delta, else: Time.to_milliseconds(delta)
+      end)
+
+    send_deltas = Enum.map(send_deltas, &Time.to_milliseconds/1)
+
+    Enum.zip_reduce(receive_deltas, send_deltas, cc, fn recv_delta, send_delta, cc ->
+      do_update(cc, recv_delta, send_delta)
+    end)
+    |> update_bandwidth(receive_deltas, packet_sizes)
+    |> update_loss(receive_deltas)
+    |> tap(
+      &Membrane.Logger.error(
+        "avg_interarrival: " <>
+          inspect(Enum.sum(&1.debug_interarrival) / length(&1.debug_interarrival))
+      )
+    )
+  end
+
+  defp update_loss(%__MODULE__{as_hat: as_hat} = cc, receive_deltas) do
+    loss = Enum.count(receive_deltas, &(&1 == :not_received))
+    loss_ratio = loss / length(receive_deltas)
+
+    as_hat =
+      cond do
+        loss_ratio < 0.02 -> 1.05 * as_hat
+        loss_ratio > 0.1 -> as_hat * (1 - 0.5 * loss_ratio)
+        true -> as_hat
+      end
+
+    %__MODULE__{as_hat: as_hat}
+  end
+
+  defp do_update(%__MODULE__{m_hat: prev_m_hat} = cc, recv_delta, send_delta) do
+    cc
+    |> update_metrics(recv_delta, send_delta)
+    |> make_signal(prev_m_hat)
+    |> then(fn {signal, cc} -> update_state(cc, signal) end)
+  end
+
+  defp update_bandwidth(cc, receive_deltas, packet_sizes) do
+    %__MODULE__{
+      r_hats: r_hats,
+      a_hat: prev_a_hat,
+      last_bandwidth_update_ts: last_bandwidth_update_ts
+    } = cc
+
+    total_size =
+      Enum.reverse(receive_deltas)
+      |> Enum.zip(Enum.reverse(packet_sizes))
+      |> Enum.reduce_while({0, 0}, fn {recv_delta, packet_size}, {time, total_size} ->
+        cond do
+          recv_delta == :not_received or recv_delta < 0 ->
+            {:cont, {time, total_size}}
+
+          recv_delta + time <= @last_packet_interval ->
+            {:cont, {time + recv_delta, total_size + packet_size}}
+
+          true ->
+            {:halt, {time, total_size}}
+        end
+      end)
+      |> then(&elem(&1, 1))
+
+    r_hat = 1 / @last_packet_interval * total_size
+
+    now = Time.monotonic_time()
+    last_bandwidth_update_ts = last_bandwidth_update_ts || now
+
+    bandwidth_update_delta =
+      Time.to_milliseconds(Time.monotonic_time() - last_bandwidth_update_ts)
+
+    a_hat =
+      case bitrate_mode(r_hat, cc) do
+        :multiplicative ->
+          eta = :math.pow(1.08, min(bandwidth_update_delta, 1))
+          eta * prev_a_hat
+
+        :additive ->
+          # rtt
+          response_time_ms = 100 + 30
+          alpha = 0.5 * min(bandwidth_update_delta / response_time_ms, 1)
+          bits_per_frame = prev_a_hat / 30
+          packets_per_frame = ceil(bits_per_frame / (1200 * 8))
+          expected_packet_size_bits = bits_per_frame / packets_per_frame
+          prev_a_hat + max(1000, alpha * expected_packet_size_bits)
+      end
+
+    a_hat = if a_hat < 1.5 * r_hat, do: @beta * r_hat, else: a_hat
+
+    %__MODULE__{
+      cc
+      | a_hat: a_hat,
+        r_hats: [r_hat | r_hats]
+    }
+  end
+
+  defp exponential_moving_average(_alpha, []), do: 0
+
+  defp exponential_moving_average(alpha, [latest_observation | older_observations]) do
+    alpha * latest_observation +
+      (1 - alpha) * exponential_moving_average(alpha, older_observations)
+  end
+
+  defp std_dev(observations) do
+    mean = Enum.sum(observations) / length(observations)
+
+    observations
+    |> Enum.map(fn obs -> (obs - mean) * (obs - mean) end)
+    |> then(&(&1 / length(observations)))
+    |> :math.sqrt()
+  end
+
+  defp bitrate_mode(r_hat, cc) do
+    exp_average = exponential_moving_average(@ema_alpha_factor, cc.r_hats)
+    std_dev = std_dev(cc.r_hats)
+
+    if r_hat > exp_average + 3 * std_dev do
+      :multiplicative
+    else
+      :additive
+    end
+  end
+
+  defp update_metrics(cc, :not_received, _send_delta), do: cc
+
+  defp update_metrics(cc, recv_delta, _send_delta) when recv_delta < 0, do: cc
+
+  defp update_metrics(cc, recv_delta, send_delta) do
+    %__MODULE__{
+      m_hat: prev_m_hat,
+      e: e,
+      var_v_hat: var_v_hat,
+      del_var_th: del_var_th,
+      last_rates: last_rates,
+      debug_interarrival: debug_interarrival
+    } = cc
+
+    interpacket_delta = recv_delta - send_delta
+
+    z = interpacket_delta - prev_m_hat
+
+    last_rates = if recv_delta != 0, do: [1 / recv_delta | last_rates], else: last_rates
+
+    f_max = Enum.max(last_rates, fn -> 0.5 end)
+
+    alpha = :math.pow(1 - @chi, 30 / (1000 * f_max))
+
+    var_v_hat = max(alpha * var_v_hat + (1 - alpha) * z * z, 1)
+
+    k = (e + @q) / (var_v_hat + e + @q)
+
+    e = (1 - k) * (e + @q)
+
+    coeff = min(z, 3 * :math.sqrt(var_v_hat))
+
+    m_hat = prev_m_hat + coeff * k
+    abs_m_hat = abs(m_hat)
+
+    del_var_th =
+      if abs_m_hat - del_var_th <= 15 do
+        coeff_K = if abs_m_hat < del_var_th, do: @coeff_K_d, else: @coeff_K_u
+        gain = recv_delta * coeff_K * (abs_m_hat - del_var_th)
+        max(min(del_var_th + gain, 600), 6)
+      else
+        del_var_th
+      end
+
+    %__MODULE__{
+      cc
+      | m_hat: m_hat,
+        var_v_hat: var_v_hat,
+        e: e,
+        last_rates: Enum.take(last_rates, 10),
+        del_var_th: del_var_th,
+        debug_interarrival: Enum.take([interpacket_delta | debug_interarrival], 1000)
+    }
+  end
+
+  defp make_signal(cc, prev_m_hat) do
+    now = Time.monotonic_time()
+    underuse_start_ts = cc.underuse_start_ts || now
+    overuse_start_ts = cc.overuse_start_ts || now
+
+    trigger_underuse? =
+      Time.to_milliseconds(now - underuse_start_ts) > cc.signal_time_th and cc.m_hat <= prev_m_hat
+
+    trigger_overuse? =
+      Time.to_milliseconds(now - overuse_start_ts) > cc.signal_time_th and cc.m_hat >= prev_m_hat
+
+    cond do
+      cc.m_hat < -cc.del_var_th and trigger_underuse? ->
+        {:underuse, %__MODULE__{cc | underuse_start_ts: now, overuse_start_ts: nil}}
+
+      cc.m_hat < -cc.del_var_th ->
+        {:normal, %__MODULE__{cc | underuse_start_ts: underuse_start_ts, overuse_start_ts: nil}}
+
+      cc.m_hat > cc.del_var_th and trigger_overuse? ->
+        {:overuse, %__MODULE__{cc | overuse_start_ts: now, underuse_start_ts: nil}}
+
+      cc.m_hat > cc.del_var_th ->
+        {:normal, %__MODULE__{cc | overuse_start_ts: overuse_start_ts, underuse_start_ts: nil}}
+
+      true ->
+        {:normal, %__MODULE__{cc | overuse_start_ts: nil, underuse_start_ts: nil}}
+    end
+  end
+
+  defp update_state(cc, signal)
+
+  defp update_state(%__MODULE__{state: :hold} = cc, :overuse),
+    do: %__MODULE__{cc | state: :decrease}
+
+  defp update_state(%__MODULE__{state: :hold} = cc, :normal),
+    do: %__MODULE__{cc | state: :increase}
+
+  defp update_state(%__MODULE__{state: :increase} = cc, :overuse),
+    do: %__MODULE__{cc | state: :decrease}
+
+  defp update_state(%__MODULE__{state: :increase} = cc, :underuse),
+    do: %__MODULE__{cc | state: :hold}
+
+  defp update_state(%__MODULE__{state: :decrease} = cc, :normal),
+    do: %__MODULE__{cc | state: :hold}
+
+  defp update_state(%__MODULE__{state: :decrease} = cc, :underuse),
+    do: %__MODULE__{cc | state: :hold}
+
+  defp update_state(cc, _signal), do: cc
+end

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -53,7 +53,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
   end
 
   setup_all do
-    # 0ms threshold allows us to get results faster in the synthetic test scenario
+    # 0ms threshold allows us to converge faster in the synthetic test scenario
     [cc: %CongestionControl{signal_time_threshold: 0}]
   end
 
@@ -133,7 +133,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         )
 
       assert cc.state == :decrease
-      assert cc.a_hat < 0.8 * initial_bwe
+      assert cc.a_hat < initial_bwe
     end
 
     test "starts to increase estimated receive bandwidth if interpacket delay decreases", %{
@@ -217,7 +217,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
           rtts
         )
 
-      assert cc.as_hat < 0.5 * initial_bwe
+      assert cc.as_hat < initial_bwe
     end
 
     test "does not modify estimated send-side bandwidth if fraction lost is moderate", %{
@@ -249,7 +249,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
           rtts
         )
 
-      assert cc.as_hat == initial_bwe
+      assert_in_delta cc.as_hat, initial_bwe, 0.01 * initial_bwe
     end
 
     test "increases estimated send-side bandwidth if fraction lost is small enough", %{
@@ -281,7 +281,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
           rtts
         )
 
-      assert cc.as_hat > 1.5 * initial_bwe
+      assert cc.as_hat > initial_bwe
     end
   end
 end

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -4,8 +4,6 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
   alias Membrane.Time
   alias Membrane.RTP.TWCCSender.CongestionControl
 
-  require Logger
-
   defp simulate_updates(cc, [], [], [], [], []), do: cc
 
   defp simulate_updates(
@@ -62,8 +60,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
   describe "Delay-based controller" do
     setup %{cc: %CongestionControl{a_hat: target_bandwidth} = cc} do
       # Setup:
-      # 20 reports delivered in a regular 100ms interval -> simulating 2s of bandwidth estimation process
-      # 10 packets per report gives us 100 packets/s
+      # 20 reports delivered in a regular 200ms interval -> simulating 4s of bandwidth estimation process
+      # 10 packets per report gives us 50 packets/s
       n_reports = 20
       packets_per_report = 10
       report_interval_ms = 200
@@ -92,7 +90,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       rtts: rtts
     } do
       receive_deltas =
-        Time.milliseconds(10)
+        Time.milliseconds(5)
         |> List.duplicate(n_reports)
         |> Enum.map(&List.duplicate(&1, packets_per_report))
 
@@ -135,10 +133,10 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         )
 
       assert cc.state == :decrease
-      assert cc.a_hat < 0.75 * initial_bwe
+      assert cc.a_hat < 0.8 * initial_bwe
     end
 
-    test "increases estimated receive bandwidth if interpacket delay decreases", %{
+    test "starts to increase estimated receive bandwidth if interpacket delay decreases", %{
       cc: %CongestionControl{a_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -1,0 +1,139 @@
+defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.Time
+  alias Membrane.RTP.TWCCSender.CongestionControl
+
+  require Bitwise
+
+  setup_all do
+    cc = %CongestionControl{signal_time_threshold: 0, target_receive_interval: Time.second()}
+    report_interval_ms = 200
+    n_reports = 20
+    packets_per_report = 10
+    packet_size = cc.a_hat / (1000 / report_interval_ms * packets_per_report)
+
+    [
+      cc: cc,
+      report_interval_ms: report_interval_ms,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      packet_size: packet_size
+    ]
+  end
+
+  defp test_update(cc, [], [], [], []), do: cc
+
+  defp test_update(
+         cc,
+         [ref_time | mock_ref_times],
+         [recv_deltas | mock_recv_deltas],
+         [send_deltas | mock_send_deltas],
+         [packet_sizes | mock_packet_sizes]
+       ) do
+    Process.sleep(1)
+
+    test_update(
+      CongestionControl.update(cc, ref_time, recv_deltas, send_deltas, packet_sizes),
+      mock_ref_times,
+      mock_recv_deltas,
+      mock_send_deltas,
+      mock_packet_sizes
+    )
+  end
+
+  describe "When interpacket delay is constant, congestion control module" do
+    test "increases estimated receive bandwidth", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      report_interval_ms: report_interval_ms,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      packet_size: packet_size
+    } do
+      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+
+      mock_recv_deltas =
+        Time.milliseconds(3)
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_send_deltas =
+        Time.milliseconds(1)
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_packet_sizes =
+        packet_size
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
+
+      assert cc.state == :increase
+      assert cc.a_hat > initial_bwe
+    end
+  end
+
+  describe "When interpacket delay increases, congestion control module" do
+    test "decreases estimated receive bandwidth", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      report_interval_ms: report_interval_ms,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      packet_size: packet_size
+    } do
+      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+
+      mock_recv_deltas =
+        1..n_reports
+        |> Enum.map(&Time.milliseconds/1)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_send_deltas =
+        Time.milliseconds(1)
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_packet_sizes =
+        packet_size
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
+
+      assert cc.state == :decrease
+      assert cc.a_hat < 0.75 * initial_bwe
+    end
+
+    test "ignores if this was a sudden spike", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      report_interval_ms: report_interval_ms,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      packet_size: packet_size
+    } do
+      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+
+      mock_recv_deltas =
+        Time.milliseconds(3)
+        |> List.duplicate(n_reports - 1)
+        |> List.insert_at(div(n_reports, 2), Time.milliseconds(20))
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_send_deltas =
+        Time.milliseconds(1)
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      mock_packet_sizes =
+        packet_size
+        |> List.duplicate(n_reports)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
+
+      assert cc.state == :increase
+      assert cc.a_hat > initial_bwe
+    end
+  end
+end

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -6,34 +6,19 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
 
   require Bitwise
 
-  setup_all do
-    cc = %CongestionControl{signal_time_threshold: 0, target_receive_interval: Time.second()}
-    report_interval_ms = 200
-    n_reports = 20
-    packets_per_report = 10
-    packet_size = cc.a_hat / (1000 / report_interval_ms * packets_per_report)
+  defp simulate_updates(cc, [], [], [], []), do: cc
 
-    [
-      cc: cc,
-      report_interval_ms: report_interval_ms,
-      n_reports: n_reports,
-      packets_per_report: packets_per_report,
-      packet_size: packet_size
-    ]
-  end
-
-  defp test_update(cc, [], [], [], []), do: cc
-
-  defp test_update(
+  defp simulate_updates(
          cc,
          [ref_time | mock_ref_times],
          [recv_deltas | mock_recv_deltas],
          [send_deltas | mock_send_deltas],
          [packet_sizes | mock_packet_sizes]
        ) do
+    # Some triggers of congestion control module require non-zero time difference between measurements
     Process.sleep(1)
 
-    test_update(
+    simulate_updates(
       CongestionControl.update(cc, ref_time, recv_deltas, send_deltas, packet_sizes),
       mock_ref_times,
       mock_recv_deltas,
@@ -42,98 +27,243 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
     )
   end
 
-  describe "When interpacket delay is constant, congestion control module" do
-    test "increases estimated receive bandwidth", %{
-      cc: %CongestionControl{a_hat: initial_bwe} = cc,
-      report_interval_ms: report_interval_ms,
-      n_reports: n_reports,
-      packets_per_report: packets_per_report,
-      packet_size: packet_size
-    } do
-      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+  describe "Delay-based controller" do
+    setup do
+      # Setup:
+      # 20 reports delivered in a regular 100ms interval -> simulating 2s of bandwidth estimation process
+      # 10 packets per report gives us 100 packets/s
+      # Packet sizes are constant and their "sending" rate equals inital bandwidth estimation
 
-      mock_recv_deltas =
-        Time.milliseconds(3)
-        |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
+      cc = %CongestionControl{signal_time_threshold: 0, target_receive_interval: Time.second()}
+      n_reports = 20
+      packets_per_report = 10
+      report_interval_ms = 200
+      avg_packet_size = cc.a_hat / (report_interval_ms / 1000) / packets_per_report
+
+      mock_ref_times = Enum.map(0..(n_reports - 1), &(Time.milliseconds(report_interval_ms) * &1))
 
       mock_send_deltas =
-        Time.milliseconds(1)
-        |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
+        Time.millisecond()
+        |> List.duplicate(n_reports * packets_per_report)
+        |> Enum.chunk_every(packets_per_report)
 
       mock_packet_sizes =
-        packet_size
+        avg_packet_size
+        |> round()
+        |> List.duplicate(n_reports * packets_per_report)
+        |> Enum.chunk_every(packets_per_report)
+
+      [
+        cc: cc,
+        n_reports: n_reports,
+        packets_per_report: packets_per_report,
+        mock_ref_times: mock_ref_times,
+        mock_send_deltas: mock_send_deltas,
+        mock_packet_sizes: mock_packet_sizes
+      ]
+    end
+
+    test "increases estimated receive bandwidth when interpacket delays are low and constant", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
+    } do
+      mock_recv_deltas =
+        Time.milliseconds(5)
         |> List.duplicate(n_reports)
         |> Enum.map(&List.duplicate(&1, packets_per_report))
 
-      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
+
+      assert cc.state == :increase
+      assert cc.a_hat > initial_bwe
+    end
+
+    test "decreases estimated receive bandwidth if interpacket delays increase", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
+    } do
+      mock_recv_deltas =
+        1..n_reports
+        |> Enum.map(&Time.milliseconds/1)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
+
+      assert cc.state == :decrease
+      assert cc.a_hat < 0.75 * initial_bwe
+    end
+
+    test "increases estimated receive bandwidth if interpacket delays decrease", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
+    } do
+      mock_recv_deltas =
+        n_reports..1//-1
+        |> Enum.map(&Time.milliseconds/1)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
 
       assert cc.state == :increase
       assert cc.a_hat > initial_bwe
     end
   end
 
-  describe "When interpacket delay increases, congestion control module" do
-    test "decreases estimated receive bandwidth", %{
-      cc: %CongestionControl{a_hat: initial_bwe} = cc,
-      report_interval_ms: report_interval_ms,
-      n_reports: n_reports,
-      packets_per_report: packets_per_report,
-      packet_size: packet_size
-    } do
-      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+  describe "Loss-based controller" do
+    setup do
+      # Setup:
+      # 5 reports delivered in a regular 500ms interval -> simulating 2.5s of bandwidth estimation process
+      # 100 packets per report gives us 1000 packets/s
+      # Packet sizes are constant and they shouldn't play role in loss-based control
 
-      mock_recv_deltas =
-        1..n_reports
-        |> Enum.map(&Time.milliseconds/1)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
+      cc = %CongestionControl{}
+      n_reports = 5
+      packets_per_report = 100
+      report_interval_ms = 500
+
+      mock_ref_times = Enum.map(0..(n_reports - 1), &(Time.milliseconds(report_interval_ms) * &1))
 
       mock_send_deltas =
-        Time.milliseconds(1)
-        |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
+        Time.millisecond()
+        |> List.duplicate(n_reports * packets_per_report)
+        |> Enum.chunk_every(packets_per_report)
 
       mock_packet_sizes =
-        packet_size
-        |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
+        1000
+        |> List.duplicate(n_reports * packets_per_report)
+        |> Enum.chunk_every(packets_per_report)
 
-      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
-
-      assert cc.state == :decrease
-      assert cc.a_hat < 0.75 * initial_bwe
+      [
+        cc: cc,
+        n_reports: n_reports,
+        packets_per_report: packets_per_report,
+        mock_ref_times: mock_ref_times,
+        mock_send_deltas: mock_send_deltas,
+        mock_packet_sizes: mock_packet_sizes
+      ]
     end
 
-    test "ignores if this was a sudden spike", %{
-      cc: %CongestionControl{a_hat: initial_bwe} = cc,
-      report_interval_ms: report_interval_ms,
+    test "decreases estimated send-side bandwidth if fraction lost is high enough", %{
+      cc: %CongestionControl{as_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
-      packet_size: packet_size
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
     } do
-      mock_ref_times = Enum.map(1..n_reports, &Time.milliseconds(report_interval_ms * &1))
+      fraction_lost = 0.2
+      packets_delivered = floor((1 - fraction_lost) * packets_per_report)
+      packets_lost = ceil(fraction_lost * packets_per_report)
 
       mock_recv_deltas =
-        Time.milliseconds(3)
-        |> List.duplicate(n_reports - 1)
-        |> List.insert_at(div(n_reports, 2), Time.milliseconds(20))
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
-
-      mock_send_deltas =
-        Time.milliseconds(1)
+        (List.duplicate(Time.milliseconds(5), packets_delivered) ++
+           List.duplicate(:not_received, packets_lost))
+        |> Enum.shuffle()
         |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
 
-      mock_packet_sizes =
-        packet_size
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
+
+      assert cc.as_hat < 0.75 * initial_bwe
+    end
+
+    test "does not modify estimated send-side bandwidth if fraction lost is moderate", %{
+      cc: %CongestionControl{as_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
+    } do
+      fraction_lost = 0.05
+      packets_delivered = floor((1 - fraction_lost) * packets_per_report)
+      packets_lost = ceil(fraction_lost * packets_per_report)
+
+      mock_recv_deltas =
+        (List.duplicate(Time.milliseconds(5), packets_delivered) ++
+           List.duplicate(:not_received, packets_lost))
+        |> Enum.shuffle()
         |> List.duplicate(n_reports)
-        |> Enum.map(&List.duplicate(&1, packets_per_report))
 
-      cc = test_update(cc, mock_ref_times, mock_recv_deltas, mock_send_deltas, mock_packet_sizes)
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
 
-      assert cc.state == :increase
-      assert cc.a_hat > initial_bwe
+      assert cc.as_hat == initial_bwe
+    end
+
+    test "increases estimated send-side bandwidth if fraction lost is small enough", %{
+      cc: %CongestionControl{as_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      mock_ref_times: mock_ref_times,
+      mock_send_deltas: mock_send_deltas,
+      mock_packet_sizes: mock_packet_sizes
+    } do
+      fraction_lost = 0.01
+      packets_delivered = floor((1 - fraction_lost) * packets_per_report)
+      packets_lost = ceil(fraction_lost * packets_per_report)
+
+      mock_recv_deltas =
+        (List.duplicate(Time.milliseconds(5), packets_delivered) ++
+           List.duplicate(:not_received, packets_lost))
+        |> Enum.shuffle()
+        |> List.duplicate(n_reports)
+
+      cc =
+        simulate_updates(
+          cc,
+          mock_ref_times,
+          mock_recv_deltas,
+          mock_send_deltas,
+          mock_packet_sizes
+        )
+
+      assert cc.as_hat > 1.25 * initial_bwe
     end
   end
 end


### PR DESCRIPTION
This PR includes implementation of [Google congestion control algorithm](https://datatracker.ietf.org/doc/html/draft-ietf-rmcat-gcc-02) with slight modifications:
- there is no pacer element - implementing it will require producing packets containing eg. empty video frames in amount that is required to match the target bitrate, we can do this in another PR.
- as there is no pacer element, interarrival deltas are measured packet-wise, not group-wise
The `RTP.SessionBin` will now send periodic notifications about estimated bandwidth at receiver.