### PR TITLE
Fix missing `handle_pad_removed` in `SSRCRouter`

### DIFF
--- a/lib/membrane/rtp/ssrc_router.ex
+++ b/lib/membrane/rtp/ssrc_router.ex
@@ -91,6 +91,9 @@ defmodule Membrane.RTP.SSRCRouter do
   end
 
   @impl true
+  def handle_pad_removed(pad, ctx, state), do: super(pad, ctx, state)
+
+  @impl true
   def handle_process(Pad.ref(:input, _id) = pad, buffer, ctx, state) do
     %Membrane.Buffer{
       metadata: %{rtp: %{ssrc: ssrc, payload_type: payload_type, extensions: extensions}}


### PR DESCRIPTION
This PR adds missing `handle_pad_removed` function clause which I accidentally removed in https://github.com/membraneframework/membrane_rtp_plugin/commit/482544abc0fd4b227e1abe1dcc6a88a085bfa497 