### PR TITLE
Fix determining late packets for big JitterBuffer latencies.

### DIFF
--- a/lib/membrane/rtp/jitter_buffer.ex
+++ b/lib/membrane/rtp/jitter_buffer.ex
@@ -126,10 +126,10 @@ defmodule Membrane.RTP.JitterBuffer do
   end
 
   defp send_buffers(%State{store: store} = state) do
-    # Shift buffers that stayed in queue longer than latency and any gaps before them
-    {too_old_records, store} = BufferStore.shift_older_than(store, state.latency)
-    # Additionally, shift buffers as long as there are no gaps
-    {buffers, store} = BufferStore.shift_ordered(store)
+    # Flushes buffers that stayed in queue longer than latency and any gaps before them
+    {too_old_records, store} = BufferStore.flush_older_than(store, state.latency)
+    # Additionally, flush buffers as long as there are no gaps
+    {buffers, store} = BufferStore.flush_ordered(store)
 
     {actions, state} = (too_old_records ++ buffers) |> Enum.map_reduce(state, &record_to_action/2)
 

--- a/lib/membrane/rtp/jitter_buffer.ex
+++ b/lib/membrane/rtp/jitter_buffer.ex
@@ -172,7 +172,7 @@ defmodule Membrane.RTP.JitterBuffer do
     # https://datatracker.ietf.org/doc/html/rfc3550#section-5.1
 
     timestamp_base =
-      case Utils.from_which_epoch(previous_timestamp, rtp_timestamp, @timestamp_limit) do
+      case Utils.from_which_rollover(previous_timestamp, rtp_timestamp, @timestamp_limit) do
         :next -> timestamp_base - @timestamp_limit
         :previous -> timestamp_base + @timestamp_limit
         :current -> timestamp_base

--- a/lib/membrane/rtp/jitter_buffer.ex
+++ b/lib/membrane/rtp/jitter_buffer.ex
@@ -172,7 +172,7 @@ defmodule Membrane.RTP.JitterBuffer do
     # https://datatracker.ietf.org/doc/html/rfc3550#section-5.1
 
     timestamp_base =
-      case Utils.from_which_cycle(previous_timestamp, rtp_timestamp, @timestamp_limit) do
+      case Utils.from_which_epoch(previous_timestamp, rtp_timestamp, @timestamp_limit) do
         :next -> timestamp_base - @timestamp_limit
         :previous -> timestamp_base + @timestamp_limit
         :current -> timestamp_base

--- a/lib/membrane/rtp/jitter_buffer/buffer_store.ex
+++ b/lib/membrane/rtp/jitter_buffer/buffer_store.ex
@@ -148,7 +148,7 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
         {nil, store}
       end
 
-    {result, bump_prev_index(store)}
+    {result, %__MODULE__{store | prev_index: store.prev_index + 1}}
   end
 
   @doc """
@@ -223,8 +223,6 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
       |> update_roc(record_epoch)
     end
   end
-
-  defp bump_prev_index(store), do: %__MODULE__{store | prev_index: store.prev_index + 1}
 
   defp update_end_index(%__MODULE__{end_index: last} = store, added_index)
        when added_index > last or last == nil,

--- a/lib/membrane/rtp/jitter_buffer/buffer_store.ex
+++ b/lib/membrane/rtp/jitter_buffer/buffer_store.ex
@@ -27,8 +27,8 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
   - `rollover_count` - count of all performed rollovers (cycles of sequence number)
   - `heap` - contains records containing buffers
   - `set` - helper structure for faster read operations; content is the same as in `heap`
-  - `flush_index` - index of the last packet that has been emitted as a result of a call
-  to one of the `flush` functions
+  - `flush_index` - index of the last packet that has been emitted (or would habe been
+  emitted, but never arrived) as a result of a call to one of the `flush` functions
   - `highest_incoming_index` - the highest index in the buffer so far, mapping to the most recently produced
   RTP packet placed in JitterBuffer
   """
@@ -132,7 +132,7 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
         {nil, store}
       end
 
-    {result, %__MODULE__{store | flush_index: store.flush_index + 1}}
+    {result, %__MODULE__{store | flush_index: expected_next_index}}
   end
 
   @doc """

--- a/lib/membrane/rtp/jitter_buffer/buffer_store.ex
+++ b/lib/membrane/rtp/jitter_buffer/buffer_store.ex
@@ -4,13 +4,6 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
   # Store for RTP packets. Packets are stored in `Heap` ordered by packet index. Packet index is
   # defined in RFC 3711 (SRTP) as: 2^16 * rollover count + sequence number.
 
-  # ## Fields
-  #   - `rollover_count` - count of all performed rollovers (cycles of sequence number)
-  #   - `heap` - contains records containing buffers
-  #   - `prev_index` - index of the last packet that has been served
-  #   - `end_index` - the highest index in the buffer so far, mapping to the most recently produced
-  #                   RTP packet placed in JitterBuffer
-
   use Bunch
   use Bunch.Access
   alias Membrane.{Buffer, RTP}
@@ -27,6 +20,17 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
             set: MapSet.new(),
             rollover_count: 0
 
+  @typedoc """
+  Type describing BufferStore structure.
+
+  Fields:
+  - `rollover_count` - count of all performed rollovers (cycles of sequence number)
+  - `heap` - contains records containing buffers
+  - `set` - helper structure for faster read operations; content is the same as in `heap`
+  - `prev_index` - index of the last packet that has been served
+  - `end_index` - the highest index in the buffer so far, mapping to the most recently produced
+  RTP packet placed in JitterBuffer
+  """
   @type t :: %__MODULE__{
           prev_index: JitterBuffer.packet_index() | nil,
           end_index: JitterBuffer.packet_index() | nil,

--- a/lib/membrane/rtp/jitter_buffer/buffer_store.ex
+++ b/lib/membrane/rtp/jitter_buffer/buffer_store.ex
@@ -77,7 +77,7 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
     prev_seq_num = rem(end_index, @seq_number_limit)
 
     {epoch, index} =
-      case Utils.from_which_cycle(prev_seq_num, seq_num, @seq_number_limit) do
+      case Utils.from_which_epoch(prev_seq_num, seq_num, @seq_number_limit) do
         :current -> {:current, seq_num + roc * @seq_number_limit}
         :previous -> {:previous, seq_num + (roc - 1) * @seq_number_limit}
         :next -> {:next, seq_num + (roc + 1) * @seq_number_limit}

--- a/lib/membrane/rtp/jitter_buffer/buffer_store.ex
+++ b/lib/membrane/rtp/jitter_buffer/buffer_store.ex
@@ -96,27 +96,6 @@ defmodule Membrane.RTP.JitterBuffer.BufferStore do
   end
 
   @doc """
-  Calculates size of the Store.
-
-  Size is calculated by counting `slots` between youngest (buffer with
-  smallest sequence number) and oldest buffer.
-
-  If Store has buffers [1,2,10] its size would be 10.
-  """
-  @spec size(__MODULE__.t()) :: number()
-  def size(store)
-  def size(%__MODULE__{heap: %Heap{data: nil}}), do: 0
-
-  def size(%__MODULE__{prev_index: nil, end_index: last, heap: heap}) do
-    size = if Heap.size(heap) == 1, do: 1, else: last - Heap.root(heap).index + 1
-    size
-  end
-
-  def size(%__MODULE__{prev_index: prev_index, end_index: end_index}) do
-    end_index - prev_index
-  end
-
-  @doc """
   Shifts the store to the buffer with the next sequence number.
 
   If this buffer is present, it will be returned.

--- a/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
+++ b/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
@@ -65,7 +65,7 @@ defmodule Membrane.RTP.TWCCReceiver.PacketInfoStore do
       seq_to_timestamp: seq_to_timestamp
     } = store
 
-    case Utils.from_which_epoch(base_seq_num, new_seq_num, @seq_number_limit) do
+    case Utils.from_which_rollover(base_seq_num, new_seq_num, @seq_number_limit) do
       :current ->
         {store, new_seq_num}
 

--- a/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
+++ b/lib/membrane/rtp/twcc_receiver/packet_info_store.ex
@@ -65,7 +65,7 @@ defmodule Membrane.RTP.TWCCReceiver.PacketInfoStore do
       seq_to_timestamp: seq_to_timestamp
     } = store
 
-    case Utils.from_which_cycle(base_seq_num, new_seq_num, @seq_number_limit) do
+    case Utils.from_which_epoch(base_seq_num, new_seq_num, @seq_number_limit) do
       :current ->
         {store, new_seq_num}
 

--- a/lib/membrane/rtp/utils.ex
+++ b/lib/membrane/rtp/utils.ex
@@ -30,12 +30,12 @@ defmodule Membrane.RTP.Utils do
     end
   end
 
-  @spec from_which_cycle(number() | nil, number(), number()) :: :current | :previous | :next
-  def from_which_cycle(previous_value, new_value, cycle_length)
+  @spec from_which_epoch(number() | nil, number(), number()) :: :current | :previous | :next
+  def from_which_epoch(previous_value, new_value, cycle_length)
 
-  def from_which_cycle(nil, _new, _cycle_length), do: :current
+  def from_which_epoch(nil, _new, _cycle_length), do: :current
 
-  def from_which_cycle(previous_value, new_value, cycle_length) do
+  def from_which_epoch(previous_value, new_value, cycle_length) do
     # a) current cycle
     distance_if_current = abs(previous_value - new_value)
     # b) new_value is from the previous cycle

--- a/lib/membrane/rtp/utils.ex
+++ b/lib/membrane/rtp/utils.ex
@@ -30,18 +30,18 @@ defmodule Membrane.RTP.Utils do
     end
   end
 
-  @spec from_which_epoch(number() | nil, number(), number()) :: :current | :previous | :next
-  def from_which_epoch(previous_value, new_value, cycle_length)
+  @spec from_which_rollover(number() | nil, number(), number()) :: :current | :previous | :next
+  def from_which_rollover(previous_value, new_value, rollover_length)
 
-  def from_which_epoch(nil, _new, _cycle_length), do: :current
+  def from_which_rollover(nil, _new, _rollover_length), do: :current
 
-  def from_which_epoch(previous_value, new_value, cycle_length) do
-    # a) current cycle
+  def from_which_rollover(previous_value, new_value, rollover_length) do
+    # a) current rollover
     distance_if_current = abs(previous_value - new_value)
-    # b) new_value is from the previous cycle
-    distance_if_previous = abs(previous_value - (new_value - cycle_length))
-    # c) new_value is in the next cycle
-    distance_if_next = abs(previous_value - (new_value + cycle_length))
+    # b) new_value is from the previous rollover
+    distance_if_previous = abs(previous_value - (new_value - rollover_length))
+    # c) new_value is in the next rollover
+    distance_if_next = abs(previous_value - (new_value + rollover_length))
 
     [
       {:current, distance_if_current},

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -124,7 +124,7 @@ defmodule Membrane.RTP.VAD do
     buffer = Header.Extension.put(buffer, new_extension)
 
     rtp_timestamp = buffer.metadata.rtp.timestamp
-    epoch = Utils.from_which_cycle(state.current_timestamp, rtp_timestamp, @timestamp_limit)
+    epoch = Utils.from_which_epoch(state.current_timestamp, rtp_timestamp, @timestamp_limit)
     current_timestamp = state.current_timestamp || 0
 
     cond do

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -124,14 +124,14 @@ defmodule Membrane.RTP.VAD do
     buffer = Header.Extension.put(buffer, new_extension)
 
     rtp_timestamp = buffer.metadata.rtp.timestamp
-    epoch = Utils.from_which_epoch(state.current_timestamp, rtp_timestamp, @timestamp_limit)
+    rollover = Utils.from_which_rollover(state.current_timestamp, rtp_timestamp, @timestamp_limit)
     current_timestamp = state.current_timestamp || 0
 
     cond do
-      epoch == :current && rtp_timestamp > current_timestamp ->
+      rollover == :current && rtp_timestamp > current_timestamp ->
         handle_vad(buffer, rtp_timestamp, level, state)
 
-      epoch == :next ->
+      rollover == :next ->
         {:ok, state} = handle_init(state)
         {{:ok, buffer: {:output, buffer}}, state}
 

--- a/test/membrane/rtp/jitter_buffer/buffer_store_test.exs
+++ b/test/membrane/rtp/jitter_buffer/buffer_store_test.exs
@@ -224,7 +224,12 @@ defmodule Membrane.RTP.JitterBuffer.BufferStoreTest do
       m = @seq_number_limit
 
       shift_index = 3 * m - 6
-      store = %BufferStore{shift_index: shift_index, end_index: shift_index, rollover_count: 2}
+
+      store = %BufferStore{
+        shift_index: shift_index,
+        highest_incoming_index: shift_index,
+        rollover_count: 2
+      }
 
       store =
         (Enum.into((m - 5)..(m - 1), []) ++ Enum.into(0..4, []))
@@ -236,7 +241,9 @@ defmodule Membrane.RTP.JitterBuffer.BufferStoreTest do
 
     test "handles late packets after a rollover" do
       indexes = [65_535, 0, 65_534]
-      store = enum_into_store(indexes, %BufferStore{shift_index: 65_533, end_index: 65_533})
+
+      store =
+        enum_into_store(indexes, %BufferStore{shift_index: 65_533, highest_incoming_index: 65_533})
 
       Enum.each(indexes, fn _index ->
         assert {%Record{}, _store} = BufferStore.shift(store)
@@ -260,7 +267,7 @@ defmodule Membrane.RTP.JitterBuffer.BufferStoreTest do
   defp new_testing_store(index) do
     %BufferStore{
       shift_index: index,
-      end_index: index,
+      highest_incoming_index: index,
       heap: Heap.new(&Record.rtp_comparator/2)
     }
   end

--- a/test/membrane/rtp/jitter_buffer_test.exs
+++ b/test/membrane/rtp/jitter_buffer_test.exs
@@ -43,8 +43,8 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When new buffer arrives when not waiting and already pushed some buffer" do
     setup %{state: state} do
-      prev_index = @base_seq_number - 1
-      store = %{state.store | prev_index: prev_index, end_index: prev_index}
+      shift_index = @base_seq_number - 1
+      store = %{state.store | shift_index: shift_index, end_index: shift_index}
       [state: %{state | waiting?: false, store: store}]
     end
 
@@ -67,8 +67,8 @@ defmodule Membrane.RTP.JitterBufferTest do
       second_buffer = BufferFactory.sample_buffer(@base_seq_number + 1)
       third_buffer = BufferFactory.sample_buffer(@base_seq_number + 2)
 
-      prev_index = @base_seq_number - 1
-      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
+      shift_index = @base_seq_number - 1
+      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
 
       store =
         with {:ok, store} <- BufferStore.insert_buffer(store, second_buffer),
@@ -90,8 +90,8 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When latency pasess without filling the gap, JitterBuffer" do
     test "outputs discontinuity and late buffer", %{state: state, buffer: buffer} do
-      prev_index = @base_seq_number - 2
-      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
+      shift_index = @base_seq_number - 2
+      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
 
       state = %{state | store: store, waiting?: false}
 
@@ -110,8 +110,8 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When event arrives" do
     test "dumps store if event was end of stream", %{state: state, buffer: buffer} do
-      prev_index = @base_seq_number - 2
-      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
+      shift_index = @base_seq_number - 2
+      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
 
       {:ok, store} = BufferStore.insert_buffer(store, buffer)
       state = %{state | store: store}

--- a/test/membrane/rtp/jitter_buffer_test.exs
+++ b/test/membrane/rtp/jitter_buffer_test.exs
@@ -43,7 +43,8 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When new buffer arrives when not waiting and already pushed some buffer" do
     setup %{state: state} do
-      store = %{state.store | prev_index: @base_seq_number - 1}
+      prev_index = @base_seq_number - 1
+      store = %{state.store | prev_index: prev_index, end_index: prev_index}
       [state: %{state | waiting?: false, store: store}]
     end
 
@@ -65,7 +66,9 @@ defmodule Membrane.RTP.JitterBufferTest do
       first_buffer = BufferFactory.sample_buffer(@base_seq_number)
       second_buffer = BufferFactory.sample_buffer(@base_seq_number + 1)
       third_buffer = BufferFactory.sample_buffer(@base_seq_number + 2)
-      store = %BufferStore{state.store | prev_index: @base_seq_number - 1}
+
+      prev_index = @base_seq_number - 1
+      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
 
       store =
         with {:ok, store} <- BufferStore.insert_buffer(store, second_buffer),
@@ -87,7 +90,9 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When latency pasess without filling the gap, JitterBuffer" do
     test "outputs discontinuity and late buffer", %{state: state, buffer: buffer} do
-      store = %BufferStore{state.store | prev_index: @base_seq_number - 2}
+      prev_index = @base_seq_number - 2
+      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
+
       state = %{state | store: store, waiting?: false}
 
       assert {{:ok, commands}, state} = JitterBuffer.handle_process(:input, buffer, nil, state)
@@ -105,7 +110,9 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When event arrives" do
     test "dumps store if event was end of stream", %{state: state, buffer: buffer} do
-      store = %BufferStore{state.store | prev_index: @base_seq_number - 2}
+      prev_index = @base_seq_number - 2
+      store = %BufferStore{state.store | prev_index: prev_index, end_index: prev_index}
+
       {:ok, store} = BufferStore.insert_buffer(store, buffer)
       state = %{state | store: store}
       assert {{:ok, actions}, _state} = JitterBuffer.handle_end_of_stream(:input, nil, state)

--- a/test/membrane/rtp/jitter_buffer_test.exs
+++ b/test/membrane/rtp/jitter_buffer_test.exs
@@ -44,7 +44,7 @@ defmodule Membrane.RTP.JitterBufferTest do
   describe "When new buffer arrives when not waiting and already pushed some buffer" do
     setup %{state: state} do
       shift_index = @base_seq_number - 1
-      store = %{state.store | shift_index: shift_index, end_index: shift_index}
+      store = %{state.store | shift_index: shift_index, highest_incoming_index: shift_index}
       [state: %{state | waiting?: false, store: store}]
     end
 
@@ -68,7 +68,12 @@ defmodule Membrane.RTP.JitterBufferTest do
       third_buffer = BufferFactory.sample_buffer(@base_seq_number + 2)
 
       shift_index = @base_seq_number - 1
-      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
+
+      store = %BufferStore{
+        state.store
+        | shift_index: shift_index,
+          highest_incoming_index: shift_index
+      }
 
       store =
         with {:ok, store} <- BufferStore.insert_buffer(store, second_buffer),
@@ -91,7 +96,12 @@ defmodule Membrane.RTP.JitterBufferTest do
   describe "When latency pasess without filling the gap, JitterBuffer" do
     test "outputs discontinuity and late buffer", %{state: state, buffer: buffer} do
       shift_index = @base_seq_number - 2
-      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
+
+      store = %BufferStore{
+        state.store
+        | shift_index: shift_index,
+          highest_incoming_index: shift_index
+      }
 
       state = %{state | store: store, waiting?: false}
 
@@ -111,7 +121,12 @@ defmodule Membrane.RTP.JitterBufferTest do
   describe "When event arrives" do
     test "dumps store if event was end of stream", %{state: state, buffer: buffer} do
       shift_index = @base_seq_number - 2
-      store = %BufferStore{state.store | shift_index: shift_index, end_index: shift_index}
+
+      store = %BufferStore{
+        state.store
+        | shift_index: shift_index,
+          highest_incoming_index: shift_index
+      }
 
       {:ok, store} = BufferStore.insert_buffer(store, buffer)
       state = %{state | store: store}

--- a/test/membrane/rtp/jitter_buffer_test.exs
+++ b/test/membrane/rtp/jitter_buffer_test.exs
@@ -36,15 +36,15 @@ defmodule Membrane.RTP.JitterBufferTest do
       assert {:ok, state} = JitterBuffer.handle_process(:input, buffer, nil, state)
 
       assert %State{store: store} = state
-      assert {%Record{buffer: ^buffer}, new_store} = BufferStore.shift(store)
+      assert {%Record{buffer: ^buffer}, new_store} = BufferStore.flush_one(store)
       assert BufferStore.dump(new_store) == []
     end
   end
 
   describe "When new buffer arrives when not waiting and already pushed some buffer" do
     setup %{state: state} do
-      shift_index = @base_seq_number - 1
-      store = %{state.store | shift_index: shift_index, highest_incoming_index: shift_index}
+      flush_index = @base_seq_number - 1
+      store = %{state.store | flush_index: flush_index, highest_incoming_index: flush_index}
       [state: %{state | waiting?: false, store: store}]
     end
 
@@ -67,12 +67,12 @@ defmodule Membrane.RTP.JitterBufferTest do
       second_buffer = BufferFactory.sample_buffer(@base_seq_number + 1)
       third_buffer = BufferFactory.sample_buffer(@base_seq_number + 2)
 
-      shift_index = @base_seq_number - 1
+      flush_index = @base_seq_number - 1
 
       store = %BufferStore{
         state.store
-        | shift_index: shift_index,
-          highest_incoming_index: shift_index
+        | flush_index: flush_index,
+          highest_incoming_index: flush_index
       }
 
       store =
@@ -95,12 +95,12 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When latency pasess without filling the gap, JitterBuffer" do
     test "outputs discontinuity and late buffer", %{state: state, buffer: buffer} do
-      shift_index = @base_seq_number - 2
+      flush_index = @base_seq_number - 2
 
       store = %BufferStore{
         state.store
-        | shift_index: shift_index,
-          highest_incoming_index: shift_index
+        | flush_index: flush_index,
+          highest_incoming_index: flush_index
       }
 
       state = %{state | store: store, waiting?: false}
@@ -120,12 +120,12 @@ defmodule Membrane.RTP.JitterBufferTest do
 
   describe "When event arrives" do
     test "dumps store if event was end of stream", %{state: state, buffer: buffer} do
-      shift_index = @base_seq_number - 2
+      flush_index = @base_seq_number - 2
 
       store = %BufferStore{
         state.store
-        | shift_index: shift_index,
-          highest_incoming_index: shift_index
+        | flush_index: flush_index,
+          highest_incoming_index: flush_index
       }
 
       {:ok, store} = BufferStore.insert_buffer(store, buffer)


### PR DESCRIPTION
Sometimes, when the `latency` in `JitterBuffer` is big enough (e.g. 5 seconds), we might start discarding packets treating them as late. Included test presents this scenario. I think that there is also a `TODO` tag directly related to this problem https://github.com/membraneframework/membrane_rtp_plugin/blob/b05114afe0ac7dacefb9488e9fb4190892b82519/lib/membrane/rtp/jitter_buffer/buffer_store.ex#L86

The initial proposal was to use `end_index` in `BufferStore` for determining late packets. However, I encountered following problems
1. This messes up current architecture of `BufferStore` and `JitterBuffer`. At the moment, we are increasing ROC (rollover count) when performing `shift` operation. Using `end_index` requires handling rollovers when adding a new buffer.
2. I am not sure what is initial latency used for. I feel like it could be deleted.
3. I feel like our JitterBuffer does not compensate network jitter. It only reorders packets. 

Having said that, I think that the decision whether we want to fix this test or not and how to do this requires further discussion.

You can run failing test with `mix test --only debug`

cc @mat-hek @bblaszkow06 