### PR TITLE
Fix selection of bwe increase mode. Fix bwe value when going into the decrease state.

### DIFF
--- a/lib/membrane/rtcp/sdes_packet.ex
+++ b/lib/membrane/rtcp/sdes_packet.ex
@@ -135,10 +135,10 @@ defmodule Membrane.RTCP.SdesPacket do
         {:priv, {prefix, value}} ->
           prefix_len = byte_size(prefix)
           total_len = 1 + prefix_len + byte_size(value)
-          <<8::8, total_len::8, prefix_len::8, prefix::binary(), value::binary()>>
+          <<8::8, total_len::8, prefix_len::8, prefix::binary, value::binary>>
 
         {key, value} ->
-          <<@sdes_type_from_atom[key]::8, byte_size(value)::8, value::binary()>>
+          <<@sdes_type_from_atom[key]::8, byte_size(value)::8, value::binary>>
       end)
 
     pad_bits = 32 - (body |> bit_size() |> rem(32))

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -8,6 +8,7 @@ defmodule Membrane.RTP.TWCCSender do
   require Bitwise
 
   alias __MODULE__.CongestionControl
+  alias __MODULE__.ReceiverRate
   alias Membrane.RTCP.TransportFeedbackPacket.TWCC
   alias Membrane.RTP
   alias Membrane.RTP.Header
@@ -62,7 +63,7 @@ defmodule Membrane.RTP.TWCCSender do
   def handle_tick(
         :bandwidth_report_timer,
         _ctx,
-        %{cc: %CongestionControl{last_r_hat: nil}} = state
+        %{cc: %CongestionControl{r_hat: %ReceiverRate{value: nil}}} = state
       ) do
     # wait until first r_hat is calculated
     {:ok, state}

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -59,6 +59,16 @@ defmodule Membrane.RTP.TWCCSender do
   end
 
   @impl true
+  def handle_tick(
+        :bandwidth_report_timer,
+        _ctx,
+        %{cc: %CongestionControl{last_r_hat: nil}} = state
+      ) do
+    # wait until first r_hat is calculated
+    {:ok, state}
+  end
+
+  @impl true
   def handle_tick(:bandwidth_report_timer, _ctx, %{cc: cc} = state) do
     {{:ok, notify: {:bandwidth_estimation, min(cc.a_hat, cc.as_hat)}}, state}
   end

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -7,8 +7,7 @@ defmodule Membrane.RTP.TWCCSender do
 
   require Bitwise
 
-  alias __MODULE__.CongestionControl
-  alias __MODULE__.ReceiverRate
+  alias __MODULE__.{CongestionControl, ReceiverRate}
   alias Membrane.RTCP.TransportFeedbackPacket.TWCC
   alias Membrane.RTP
   alias Membrane.RTP.Header

--- a/lib/membrane/rtp/twcc_sender.ex
+++ b/lib/membrane/rtp/twcc_sender.ex
@@ -65,7 +65,7 @@ defmodule Membrane.RTP.TWCCSender do
         _ctx,
         %{cc: %CongestionControl{r_hat: %ReceiverRate{value: nil}}} = state
       ) do
-    # wait until first r_hat is calculated
+    # wait until the first r_hat is calculated
     {:ok, state}
   end
 

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -25,8 +25,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
   # alpha factor for exponential moving average
   @ema_smoothing_factor 0.95
 
-  @last_receive_rates_probe_size 25
-  @last_receive_bandwidth_probe_size 25
+  @last_receive_rates_size 25
+  @decrease_r_hats_size 25
 
   defstruct [
     # inter-packet delay estimate (in ms)
@@ -52,15 +52,13 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     # sender-side bandwidth estimation in bps
     as_hat: 300_000.0,
     # latest receiver-side incoming bitrates when we were in the decrease state
-    r_hats: [],
+    decrease_r_hats: [],
+    # latest receiver-side incoming bitrate
+    last_r_hat: 0.0,
     # time window for measuring the received bitrate, between [0.5, 1]s (reffered to as "T" in the RFC)
-    target_receive_interval: Time.milliseconds(750),
-    # accumulator for packet sizes in bits that have been received through target_receive_interval
-    packet_received_sizes: 0,
-    # starting timestamp for current packet received interval
-    packet_received_interval_start: nil,
-    # last timestamp for current packet received interval
-    packet_received_interval_end: nil,
+    target_receive_window: Time.milliseconds(750),
+    # accumulator for packets and their timestamps that have been received through target_receive_interval
+    packets_received: [],
     # time required to trigger a signal (reffered to as "overuse_time_th" in the RFC)
     signal_time_threshold: Time.milliseconds(10)
   ]
@@ -77,10 +75,9 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
           last_bandwidth_increase_ts: Time.t(),
           a_hat: float(),
           as_hat: float(),
-          r_hats: [float()],
-          packet_received_sizes: non_neg_integer(),
-          packet_received_interval_start: Time.t() | nil,
-          packet_received_interval_end: Time.t() | nil
+          decrease_r_hats: [float()],
+          last_r_hat: float(),
+          packets_received: [{Membrane.Time.t(), non_neg_integer()}]
         }
 
   @spec update(t(), Time.t(), [Time.t() | :not_received], [Time.t()], [pos_integer()], Time.t()) ::
@@ -95,7 +92,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
       ) do
     cc
     |> update_metrics(receive_deltas, send_deltas)
-    |> store_packet_received_sizes(reference_time, receive_deltas, packet_sizes)
+    |> update_receiver_bitrate(reference_time, receive_deltas, packet_sizes)
     |> update_receiver_bandwidth(packet_sizes, rtt)
     |> update_sender_bandwidth(receive_deltas)
   end
@@ -176,7 +173,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
       | m_hat: m_hat,
         var_v_hat: var_v_hat,
         e: e,
-        last_receive_rates: Enum.take(last_receive_rates, @last_receive_rates_probe_size),
+        last_receive_rates: Enum.take(last_receive_rates, @last_receive_rates_size),
         del_var_th: del_var_th
     }
 
@@ -254,60 +251,44 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
   defp update_state(cc, _signal), do: cc
 
-  defp store_packet_received_sizes(cc, reference_time, receive_deltas, packet_sizes) do
-    %__MODULE__{
-      packet_received_interval_start: packet_received_interval_start,
-      packet_received_interval_end: packet_received_interval_end,
-      packet_received_sizes: packet_received_sizes
-    } = cc
+  defp update_receiver_bitrate(cc, reference_time, receive_deltas, packet_sizes) do
+    %__MODULE__{target_receive_window: receive_window} = cc
 
-    {receive_deltas, packet_sizes} =
+    packets_received =
       receive_deltas
       |> Enum.zip(packet_sizes)
       |> Enum.filter(fn {delta, _size} -> delta != :not_received end)
-      |> Enum.unzip()
+      |> Enum.scan({reference_time, List.first(packet_sizes)}, fn {recv_delta, size},
+                                                                  {prev_timestamp, _prev_size} ->
+        {prev_timestamp + recv_delta, size}
+      end)
 
-    timestamp_received = Enum.scan(receive_deltas, reference_time, &(&1 + &2))
-    {earliest_packet_ts, latest_packet_ts} = Enum.min_max(timestamp_received)
+    {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
 
-    packet_received_interval_start = packet_received_interval_start || earliest_packet_ts
-    packet_received_interval_end = packet_received_interval_end || latest_packet_ts
+    treshold = last_packet_timestamp - receive_window
 
-    %__MODULE__{
-      cc
-      | packet_received_interval_start: min(packet_received_interval_start, earliest_packet_ts),
-        packet_received_interval_end: max(packet_received_interval_end, latest_packet_ts),
-        packet_received_sizes: packet_received_sizes + Enum.sum(packet_sizes)
-    }
+    packets_received =
+      (cc.packets_received ++ packets_received)
+      |> Enum.drop_while(fn {timestamp, _size} -> timestamp < treshold end)
+
+    packet_received_sizes = Enum.map(packets_received, fn {_timestamp, size} -> size end)
+
+    r_hat =
+      1 / (Time.as_milliseconds(cc.target_receive_window) / 1000) *
+        Enum.sum(packet_received_sizes)
+
+    %__MODULE__{cc | last_r_hat: r_hat, packets_received: packets_received}
   end
 
-  defp update_receiver_bandwidth(
-         %__MODULE__{
-           state: state,
-           packet_received_interval_end: packet_received_interval_end,
-           packet_received_interval_start: packet_received_interval_start,
-           packet_received_sizes: packet_received_sizes
-         } = cc,
-         packet_sizes,
-         rtt
-       )
-       when packet_received_interval_end - packet_received_interval_start >=
-              cc.target_receive_interval do
-    packet_received_interval_ms =
-      Time.to_milliseconds(packet_received_interval_end - packet_received_interval_start)
-
-    r_hat = 1 / (packet_received_interval_ms / 1000) * packet_received_sizes
-
+  defp update_receiver_bandwidth(%__MODULE__{state: state} = cc, packet_sizes, rtt) do
     case state do
-      :increase -> increase_receiver_bandwidth(cc, packet_sizes, rtt, r_hat)
-      :decrease -> decrease_receiver_bandwidth(cc, r_hat)
+      :increase -> increase_receiver_bandwidth(cc, packet_sizes, rtt)
+      :decrease -> decrease_receiver_bandwidth(cc)
       :hold -> cc
     end
   end
 
-  defp update_receiver_bandwidth(cc, _packet_sizes, _rtt), do: cc
-
-  defp increase_receiver_bandwidth(cc, packet_sizes, rtt, r_hat) do
+  defp increase_receiver_bandwidth(cc, packet_sizes, rtt) do
     %__MODULE__{
       a_hat: prev_a_hat,
       last_bandwidth_increase_ts: last_bandwidth_increase_ts
@@ -318,7 +299,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     time_since_last_update_ms = Time.to_milliseconds(now - last_bandwidth_increase_ts)
 
     a_hat =
-      case bitrate_increase_mode(r_hat, cc) do
+      case bitrate_increase_mode(cc) do
         :multiplicative ->
           eta = :math.pow(1.08, min(time_since_last_update_ms / 1000, 1))
           eta * prev_a_hat
@@ -330,23 +311,16 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
           prev_a_hat + max(1000, alpha * expected_packet_size_bits)
       end
 
-    a_hat = min(1.5 * r_hat, a_hat)
+    a_hat = min(1.5 * cc.last_r_hat, a_hat)
 
-    %__MODULE__{
-      cc
-      | a_hat: a_hat,
-        last_bandwidth_increase_ts: now,
-        packet_received_interval_end: nil,
-        packet_received_interval_start: nil,
-        packet_received_sizes: 0
-    }
+    %__MODULE__{cc | a_hat: a_hat, last_bandwidth_increase_ts: now}
   end
 
-  defp decrease_receiver_bandwidth(cc, r_hat) do
+  defp decrease_receiver_bandwidth(cc) do
     %__MODULE__{
       cc
-      | a_hat: @beta * cc.a_hat,
-        r_hats: Enum.take([r_hat | cc.r_hats], @last_receive_bandwidth_probe_size)
+      | a_hat: @beta * cc.last_r_hat,
+        decrease_r_hats: Enum.take([cc.last_r_hat | cc.decrease_r_hats], @decrease_r_hats_size)
     }
   end
 
@@ -364,15 +338,13 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     %__MODULE__{cc | as_hat: min(as_hat, 1.5 * a_hat)}
   end
 
-  defp bitrate_increase_mode(_r_hat, %__MODULE__{r_hats: prev_r_hats})
-       when length(prev_r_hats) < @last_receive_bandwidth_probe_size,
-       do: :multiplicative
+  defp bitrate_increase_mode(%__MODULE__{decrease_r_hats: []}), do: :multiplicative
 
-  defp bitrate_increase_mode(r_hat, %__MODULE__{r_hats: prev_r_hats}) do
-    exp_average = exponential_moving_average(@ema_smoothing_factor, prev_r_hats)
-    std_dev = std_dev(prev_r_hats)
+  defp bitrate_increase_mode(%__MODULE__{decrease_r_hats: decrease_r_hats, last_r_hat: last_r_hat}) do
+    exp_average = exponential_moving_average(@ema_smoothing_factor, decrease_r_hats)
+    std_dev = std_dev(decrease_r_hats)
 
-    if abs(r_hat - exp_average) <= 3 * std_dev do
+    if abs(last_r_hat - exp_average) <= 3 * std_dev do
       :additive
     else
       :multiplicative

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -5,8 +5,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
 
   require Membrane.Logger
 
-  alias Membrane.Time
   alias Membrane.RTP.TWCCSender.ReceiverRate
+  alias Membrane.Time
 
   # disable Credo naming checks to use the RFC notation
   # credo:disable-for-this-file /(ModuleAttributeNames|VariableNames)/

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -280,7 +280,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     time_since_last_update_ms = Time.to_milliseconds(now - last_bandwidth_increase_ts)
 
     a_hat =
-      case bitrate_increase_mode(cc) do
+      case bandwidth_increase_mode(cc) do
         :multiplicative ->
           eta = :math.pow(1.08, min(time_since_last_update_ms / 1000, 1))
           eta * prev_a_hat
@@ -319,9 +319,9 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     %__MODULE__{cc | as_hat: min(as_hat, 1.5 * a_hat)}
   end
 
-  defp bitrate_increase_mode(%__MODULE__{decrease_r_hats: []}), do: :multiplicative
+  defp bandwidth_increase_mode(%__MODULE__{decrease_r_hats: []}), do: :multiplicative
 
-  defp bitrate_increase_mode(%__MODULE__{decrease_r_hats: decrease_r_hats, r_hat: r_hat}) do
+  defp bandwidth_increase_mode(%__MODULE__{decrease_r_hats: decrease_r_hats, r_hat: r_hat}) do
     exp_average = exponential_moving_average(@ema_smoothing_factor, decrease_r_hats)
     std_dev = std_dev(decrease_r_hats)
 

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -1,7 +1,6 @@
 defmodule Membrane.RTP.TWCCSender.CongestionControl do
-  @moduledoc """
-  The module implements [Google congestion control algorithm](https://datatracker.ietf.org/doc/html/draft-ietf-rmcat-gcc-02).
-  """
+  @moduledoc false
+  # The module implements [Google congestion control algorithm](https://datatracker.ietf.org/doc/html/draft-ietf-rmcat-gcc-02).
 
   require Membrane.Logger
 

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -25,8 +25,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
   # alpha factor for exponential moving average
   @ema_smoothing_factor 0.95
 
-  @last_receive_rates_size 25
-  @decrease_r_hats_size 25
+  @last_receive_rates_kept 25
+  @decrease_r_hats_kept 25
 
   defstruct [
     # inter-packet delay estimate (in ms)
@@ -51,9 +51,9 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     a_hat: 300_000.0,
     # sender-side bandwidth estimation in bps
     as_hat: 300_000.0,
-    # latest receiver-side incoming bitrates when we were in the decrease state
+    # latest receiver-side incoming bitrate estimations when we were in the decrease state
     decrease_r_hats: [],
-    # latest receiver-side incoming bitrate
+    # latest receiver-side incoming bitrate estimation
     r_hat: ReceiverRate.new(Time.milliseconds(750)),
     # time required to trigger a signal (reffered to as "overuse_time_th" in the RFC)
     signal_time_threshold: Time.milliseconds(10)
@@ -168,7 +168,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
       | m_hat: m_hat,
         var_v_hat: var_v_hat,
         e: e,
-        last_receive_rates: Enum.take(last_receive_rates, @last_receive_rates_size),
+        last_receive_rates: Enum.take(last_receive_rates, @last_receive_rates_kept),
         del_var_th: del_var_th
     }
 
@@ -300,7 +300,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     %__MODULE__{
       cc
       | a_hat: @beta * cc.r_hat.value,
-        decrease_r_hats: Enum.take([cc.r_hat | cc.decrease_r_hats], @decrease_r_hats_size)
+        decrease_r_hats: Enum.take([cc.r_hat | cc.decrease_r_hats], @decrease_r_hats_kept)
     }
   end
 

--- a/lib/membrane/rtp/twcc_sender/congestion_control.ex
+++ b/lib/membrane/rtp/twcc_sender/congestion_control.ex
@@ -267,7 +267,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControl do
     {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
 
     if last_packet_timestamp - first_packet_timestamp >= receive_window do
-      cc = %__MODULE__{cc | last_r_hat: 0.0, packets_received: packets_received}
+      cc = %__MODULE__{cc | last_r_hat: 0.0}
       update_receiver_bitrate(cc, reference_time, receive_deltas, packet_sizes)
     else
       %__MODULE__{cc | packets_received: packets_received}

--- a/lib/membrane/rtp/twcc_sender/receiver_rate.ex
+++ b/lib/membrane/rtp/twcc_sender/receiver_rate.ex
@@ -2,19 +2,20 @@ defmodule Membrane.RTP.TWCCSender.ReceiverRate do
   @moduledoc false
   # module responsible for calculating bitrate
   # received by a receiver in last `window` time
+  # (referred to as R_hat in the GCC draft, sec. 5.5)
 
   alias Membrane.Time
 
   @type t() :: %__MODULE__{
           value: float() | nil,
-          # time window for measuring the received bitrate, between [0.5, 1]s (reffered to as "T" in the RFC)
+          # time window for measuring the received bitrate, between [0.5, 1]s (reffered to as "T" in the draft)
           window: Time.t(),
-          # accumulator for packets and their timestamps that have been received through target_receive_interval
-          packets_received: [{Time.t(), pos_integer()}]
+          # accumulator for packets and their timestamps that have been received in last `window` time
+          packets_received: :queue.queue({Time.t(), pos_integer()})
         }
 
   @enforce_keys [:window]
-  defstruct @enforce_keys ++ [:value, packets_received: []]
+  defstruct @enforce_keys ++ [:value, packets_received: :queue.new()]
 
   @spec new(Time.t()) :: t()
   def new(window), do: %__MODULE__{window: window}
@@ -23,10 +24,10 @@ defmodule Membrane.RTP.TWCCSender.ReceiverRate do
   def update(%__MODULE__{value: nil} = rr, reference_time, receive_deltas, packet_sizes) do
     packets_received = resolve_receive_deltas(receive_deltas, reference_time, packet_sizes)
 
-    packets_received = rr.packets_received ++ packets_received
+    packets_received = :queue.join(rr.packets_received, packets_received)
 
-    {first_packet_timestamp, _first_packet_size} = List.first(packets_received)
-    {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
+    {first_packet_timestamp, _first_packet_size} = :queue.get(packets_received)
+    {last_packet_timestamp, _last_packet_size} = :queue.get_r(packets_received)
 
     if last_packet_timestamp - first_packet_timestamp >= rr.window do
       rr = %__MODULE__{rr | value: 0.0}
@@ -39,17 +40,18 @@ defmodule Membrane.RTP.TWCCSender.ReceiverRate do
   def update(%__MODULE__{} = rr, reference_time, receive_deltas, packet_sizes) do
     packets_received = resolve_receive_deltas(receive_deltas, reference_time, packet_sizes)
 
-    {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
+    {last_packet_timestamp, _last_packet_size} = :queue.get_r(packets_received)
 
     treshold = last_packet_timestamp - rr.window
 
+    packets_received = :queue.join(rr.packets_received, packets_received)
+
     packets_received =
-      (rr.packets_received ++ packets_received)
-      |> Enum.drop_while(fn {timestamp, _size} -> timestamp < treshold end)
+      :queue.filter(fn {timestamp, _size} -> timestamp > treshold end, packets_received)
 
-    packet_received_sizes = Enum.map(packets_received, fn {_timestamp, size} -> size end)
+    sum = :queue.fold(fn {_timestamp, size}, size_sum -> size + size_sum end, 0, packets_received)
 
-    value = 1 / (Time.as_milliseconds(rr.window) / 1000) * Enum.sum(packet_received_sizes)
+    value = 1 / (Time.as_milliseconds(rr.window) / 1000) * sum
 
     %__MODULE__{rr | value: value, packets_received: packets_received}
   end
@@ -58,9 +60,12 @@ defmodule Membrane.RTP.TWCCSender.ReceiverRate do
     receive_deltas
     |> Enum.zip(packet_sizes)
     |> Enum.filter(fn {delta, _size} -> delta != :not_received end)
-    |> Enum.scan({reference_time, List.first(packet_sizes)}, fn {recv_delta, size},
-                                                                {prev_timestamp, _prev_size} ->
-      {prev_timestamp + recv_delta, size}
+    |> Enum.reduce({reference_time, :queue.new()}, fn {recv_delta, size},
+                                                      {prev_timestamp, packets_received} ->
+      receive_timestamp = prev_timestamp + recv_delta
+      {receive_timestamp, :queue.in({receive_timestamp, size}, packets_received)}
     end)
+    # take the packets_received
+    |> elem(1)
   end
 end

--- a/lib/membrane/rtp/twcc_sender/receiver_rate.ex
+++ b/lib/membrane/rtp/twcc_sender/receiver_rate.ex
@@ -1,0 +1,66 @@
+defmodule Membrane.RTP.TWCCSender.ReceiverRate do
+  @moduledoc false
+  # module responsible for calculating bitrate
+  # received by a receiver in last `window` time
+
+  alias Membrane.Time
+
+  @type t() :: %__MODULE__{
+          value: float() | nil,
+          # time window for measuring the received bitrate, between [0.5, 1]s (reffered to as "T" in the RFC)
+          window: Time.t(),
+          # accumulator for packets and their timestamps that have been received through target_receive_interval
+          packets_received: [{Time.t(), pos_integer()}]
+        }
+
+  @enforce_keys [:window]
+  defstruct @enforce_keys ++ [:value, packets_received: []]
+
+  @spec new(Time.t()) :: t()
+  def new(window), do: %__MODULE__{window: window}
+
+  @spec update(t(), Time.t(), [Time.t() | :not_received], [pos_integer()]) :: t()
+  def update(%__MODULE__{value: nil} = rr, reference_time, receive_deltas, packet_sizes) do
+    packets_received = resolve_receive_deltas(receive_deltas, reference_time, packet_sizes)
+
+    packets_received = rr.packets_received ++ packets_received
+
+    {first_packet_timestamp, _first_packet_size} = List.first(packets_received)
+    {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
+
+    if last_packet_timestamp - first_packet_timestamp >= rr.window do
+      rr = %__MODULE__{rr | value: 0.0}
+      update(rr, reference_time, receive_deltas, packet_sizes)
+    else
+      %__MODULE__{rr | packets_received: packets_received}
+    end
+  end
+
+  def update(%__MODULE__{} = rr, reference_time, receive_deltas, packet_sizes) do
+    packets_received = resolve_receive_deltas(receive_deltas, reference_time, packet_sizes)
+
+    {last_packet_timestamp, _last_packet_size} = List.last(packets_received)
+
+    treshold = last_packet_timestamp - rr.window
+
+    packets_received =
+      (rr.packets_received ++ packets_received)
+      |> Enum.drop_while(fn {timestamp, _size} -> timestamp < treshold end)
+
+    packet_received_sizes = Enum.map(packets_received, fn {_timestamp, size} -> size end)
+
+    value = 1 / (Time.as_milliseconds(rr.window) / 1000) * Enum.sum(packet_received_sizes)
+
+    %__MODULE__{rr | value: value, packets_received: packets_received}
+  end
+
+  defp resolve_receive_deltas(receive_deltas, reference_time, packet_sizes) do
+    receive_deltas
+    |> Enum.zip(packet_sizes)
+    |> Enum.filter(fn {delta, _size} -> delta != :not_received end)
+    |> Enum.scan({reference_time, List.first(packet_sizes)}, fn {recv_delta, size},
+                                                                {prev_timestamp, _prev_size} ->
+      {prev_timestamp + recv_delta, size}
+    end)
+  end
+end

--- a/test/membrane/rtp/packet_test.exs
+++ b/test/membrane/rtp/packet_test.exs
@@ -22,8 +22,8 @@ defmodule Membrane.RTP.PacketTest do
   end
 
   test "parses and serializes csrcs correctly" do
-    <<header_1::4, _old_cc::4, header_2::88, payload::binary()>> = Fixtures.sample_packet_binary()
-    packet_binary = <<header_1::4, 2::4, header_2::88, 12::32, 21::32, payload::binary()>>
+    <<header_1::4, _old_cc::4, header_2::88, payload::binary>> = Fixtures.sample_packet_binary()
+    packet_binary = <<header_1::4, 2::4, header_2::88, 12::32, 21::32, payload::binary>>
 
     packet = %Packet{
       Fixtures.sample_packet()

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -214,9 +214,9 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
     } do
       # when sending with a rate much higher than the bwe
       # we should finally overuse the connection;
-      # this should result in changing the sate to `:decrease`
-      # and setting the bwe to 0.85 * r_hat where r_hat is
-      # the last receiver bitrate i.e. our bwe should
+      # this should result in changing the state to `:decrease`
+      # and setting the bwe to 0.85 * r_hat, where r_hat is
+      # the last receiver bitrate. That means our bwe should
       # be bumped by a lot
 
       rate = initial_bwe * 10

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -245,8 +245,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         )
 
       assert cc.state == :decrease
-      assert cc.a_hat >= 0.80 * rate
-      assert cc.a_hat <= 0.95 * rate
+      assert_in_delta cc.a_hat / rate, 0.85, 0.95
     end
 
     test "starts to increase estimated receive bandwidth if interpacket delay decreases", %{

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -108,6 +108,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       assert cc.a_hat > initial_bwe
     end
 
+    @tag :debug
     test "decreases estimated receive bandwidth if interpacket delay increases", %{
       cc: %CongestionControl{a_hat: initial_bwe} = cc,
       n_reports: n_reports,
@@ -252,6 +253,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       assert_in_delta cc.as_hat, initial_bwe, 0.01 * initial_bwe
     end
 
+    @tag :debug
     test "increases estimated send-side bandwidth if fraction lost is small enough", %{
       cc: %CongestionControl{as_hat: initial_bwe} = cc,
       n_reports: n_reports,

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -82,7 +82,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
     packets_per_report = 10
     report_interval_ms = 200
     # +1 because of small send deltas and the way r_hat is calculated
-    n_reports = ceil(cc.target_receive_window / Time.milliseconds(report_interval_ms)) + 1
+    n_reports = ceil(cc.r_hat.window / Time.milliseconds(report_interval_ms)) + 1
 
     {reference_times, send_deltas, packet_sizes, rtts} =
       make_fixtures(cc.a_hat, n_reports, packets_per_report, report_interval_ms, 0)
@@ -103,7 +103,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         rtts
       )
 
-    assert cc.last_r_hat != nil
+    assert cc.r_hat.value != nil
 
     initial_reference_time = List.last(reference_times) + Time.milliseconds(report_interval_ms)
 

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -4,18 +4,25 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
   alias Membrane.RTP.TWCCSender.CongestionControl
   alias Membrane.Time
 
-  defp simulate_updates(cc, [], [], [], [], []), do: cc
+  defp simulate_updates(cc, _report_interval, [], [], [], [], []), do: cc
 
   defp simulate_updates(
          cc,
+         report_interval,
          [reference_time | remaining_reference_times],
          [receive_deltas | remaining_receive_deltas],
          [send_deltas | remaining_send_deltas],
          [packet_sizes | remaining_packet_sizes],
          [rtt | remaining_rtts]
        ) do
-    IO.inspect({cc.state, cc.a_hat})
-    Process.sleep(200)
+    last_bandwidth_increase_ts =
+      if cc.state == :increase do
+        Time.vm_time() - report_interval
+      else
+        cc.last_bandwidth_increase_ts - report_interval
+      end
+
+    cc = %CongestionControl{cc | last_bandwidth_increase_ts: last_bandwidth_increase_ts}
 
     simulate_updates(
       CongestionControl.update(
@@ -26,6 +33,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         packet_sizes,
         rtt
       ),
+      report_interval,
       remaining_reference_times,
       remaining_receive_deltas,
       remaining_send_deltas,
@@ -34,15 +42,25 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
     )
   end
 
-  defp make_fixtures(target_bandwidth, n_reports, packets_per_report, report_interval_ms) do
-    reference_times = Enum.map(0..(n_reports - 1), &(Time.milliseconds(report_interval_ms) * &1))
+  defp make_fixtures(
+         target_bandwidth,
+         n_reports,
+         packets_per_report,
+         report_interval_ms,
+         initial_reference_time
+       ) do
+    reference_times =
+      Enum.map(
+        0..(n_reports - 1),
+        &(initial_reference_time + Time.milliseconds(report_interval_ms) * &1)
+      )
 
     send_deltas =
       Time.millisecond()
       |> List.duplicate(n_reports * packets_per_report)
       |> Enum.chunk_every(packets_per_report)
 
-    avg_packet_size = target_bandwidth / (report_interval_ms / 1000) / packets_per_report
+    avg_packet_size = target_bandwidth * (report_interval_ms / 1000) / packets_per_report
 
     packet_sizes =
       avg_packet_size
@@ -57,26 +75,67 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
 
   setup_all do
     # 0ms threshold allows us to converge faster in the synthetic test scenario
-    [cc: %CongestionControl{signal_time_threshold: 0}]
+    cc = %CongestionControl{signal_time_threshold: 0}
+
+    # simulate initial traffic to calculate first r_hat
+    # 10 packets per report gives us 50 packets/s
+    packets_per_report = 10
+    report_interval_ms = 200
+    # +1 because of small send deltas and the way r_hat is calculated
+    n_reports = ceil(cc.target_receive_window / Time.milliseconds(report_interval_ms)) + 1
+
+    {reference_times, send_deltas, packet_sizes, rtts} =
+      make_fixtures(cc.a_hat, n_reports, packets_per_report, report_interval_ms, 0)
+
+    receive_deltas =
+      Time.milliseconds(1)
+      |> List.duplicate(n_reports)
+      |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+    cc =
+      simulate_updates(
+        cc,
+        Time.milliseconds(report_interval_ms),
+        reference_times,
+        receive_deltas,
+        send_deltas,
+        packet_sizes,
+        rtts
+      )
+
+    assert cc.last_r_hat != nil
+
+    initial_reference_time = List.last(reference_times) + Time.milliseconds(report_interval_ms)
+
+    [cc: cc, initial_reference_time: initial_reference_time]
   end
 
   describe "Delay-based controller" do
-    setup %{cc: %CongestionControl{a_hat: target_bandwidth} = cc} do
+    setup %{
+      cc: %CongestionControl{a_hat: target_bandwidth} = cc,
+      initial_reference_time: initial_reference_time
+    } do
       # Setup:
       # 20 reports delivered in a regular 200ms interval -> simulating 4s of bandwidth estimation process
-      packet_size = 1200 * 8
-      n_reports = 132
-      report_interval_ms = 30
-
-      packets_per_report = round(target_bandwidth / packet_size * (report_interval_ms / 1000)) |> IO.inspect(label: :packets_per_report)
+      # 10 packets per report gives us 50 packets/s
+      n_reports = 20
+      packets_per_report = 10
+      report_interval_ms = 200
 
       {reference_times, send_deltas, packet_sizes, rtts} =
-        make_fixtures(target_bandwidth, n_reports, packets_per_report, report_interval_ms)
+        make_fixtures(
+          target_bandwidth,
+          n_reports,
+          packets_per_report,
+          report_interval_ms,
+          initial_reference_time
+        )
 
       [
         cc: cc,
         n_reports: n_reports,
         packets_per_report: packets_per_report,
+        report_interval: Time.milliseconds(report_interval_ms),
         reference_times: reference_times,
         send_deltas: send_deltas,
         packet_sizes: packet_sizes,
@@ -88,6 +147,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc: %CongestionControl{a_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       reference_times: reference_times,
       send_deltas: send_deltas,
       packet_sizes: packet_sizes,
@@ -101,6 +161,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,
@@ -112,11 +173,11 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       assert cc.a_hat > initial_bwe
     end
 
-    @tag :debug
     test "decreases estimated receive bandwidth if interpacket delay increases", %{
       cc: %CongestionControl{a_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       reference_times: reference_times,
       send_deltas: send_deltas,
       packet_sizes: packet_sizes,
@@ -130,6 +191,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,
@@ -141,10 +203,58 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       assert cc.a_hat < initial_bwe
     end
 
+    test "bumps a lot estimated receive bandwidth if congesting the channel with rate much higher than the estimation",
+         %{
+           cc: %CongestionControl{a_hat: initial_bwe} = cc,
+           n_reports: n_reports,
+           packets_per_report: packets_per_report,
+           report_interval: report_interval,
+           reference_times: reference_times,
+           send_deltas: send_deltas,
+           rtts: rtts
+         } do
+      # when sending with a rate much higher than the bwe
+      # we should finally overuse the connection;
+      # this should result in changing the sate to `:decrease`
+      # and setting the bwe to 0.85 * r_hat where r_hat is
+      # the last receiver bitrate i.e. our bwe should
+      # be bumped by a lot
+
+      rate = initial_bwe * 10
+      report_interval_ms = 200
+      packet_size = rate * (report_interval_ms / 1000) / packets_per_report
+
+      packet_sizes =
+        packet_size
+        |> List.duplicate(n_reports * packets_per_report)
+        |> Enum.chunk_every(packets_per_report)
+
+      receive_deltas =
+        1..n_reports
+        |> Enum.map(&Time.milliseconds/1)
+        |> Enum.map(&List.duplicate(&1, packets_per_report))
+
+      cc =
+        simulate_updates(
+          cc,
+          report_interval,
+          reference_times,
+          receive_deltas,
+          send_deltas,
+          packet_sizes,
+          rtts
+        )
+
+      assert cc.state == :decrease
+      assert cc.a_hat >= 0.80 * rate
+      assert cc.a_hat <= 0.95 * rate
+    end
+
     test "starts to increase estimated receive bandwidth if interpacket delay decreases", %{
       cc: %CongestionControl{a_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       reference_times: reference_times,
       send_deltas: send_deltas,
       packet_sizes: packet_sizes,
@@ -158,6 +268,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,
@@ -171,7 +282,10 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
   end
 
   describe "Loss-based controller" do
-    setup %{cc: %CongestionControl{as_hat: target_bandwidth} = cc} do
+    setup %{
+      cc: %CongestionControl{as_hat: target_bandwidth} = cc,
+      initial_reference_time: initial_reference_time
+    } do
       # Setup:
       # 10 reports delivered in a regular 200ms interval -> simulating 2s of bandwidth estimation process
       # 100 packets per report gives us 500 packets/s
@@ -180,12 +294,19 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       report_interval_ms = 200
 
       {reference_times, send_deltas, packet_sizes, rtts} =
-        make_fixtures(target_bandwidth, n_reports, packets_per_report, report_interval_ms)
+        make_fixtures(
+          target_bandwidth,
+          n_reports,
+          packets_per_report,
+          report_interval_ms,
+          initial_reference_time
+        )
 
       [
         cc: cc,
         n_reports: n_reports,
         packets_per_report: packets_per_report,
+        report_interval: Time.milliseconds(report_interval_ms),
         reference_times: reference_times,
         send_deltas: send_deltas,
         packet_sizes: packet_sizes,
@@ -197,6 +318,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc: %CongestionControl{as_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       rtts: rtts,
       reference_times: reference_times,
       send_deltas: send_deltas,
@@ -215,6 +337,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,
@@ -229,6 +352,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc: %CongestionControl{as_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       rtts: rtts,
       reference_times: reference_times,
       send_deltas: send_deltas,
@@ -247,6 +371,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,
@@ -261,6 +386,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc: %CongestionControl{as_hat: initial_bwe} = cc,
       n_reports: n_reports,
       packets_per_report: packets_per_report,
+      report_interval: report_interval,
       rtts: rtts,
       reference_times: reference_times,
       send_deltas: send_deltas,
@@ -279,6 +405,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       cc =
         simulate_updates(
           cc,
+          report_interval,
           reference_times,
           receive_deltas,
           send_deltas,

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -203,16 +203,15 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       assert cc.a_hat < initial_bwe
     end
 
-    test "bumps a lot estimated receive bandwidth if congesting the channel with rate much higher than the estimation",
-         %{
-           cc: %CongestionControl{a_hat: initial_bwe} = cc,
-           n_reports: n_reports,
-           packets_per_report: packets_per_report,
-           report_interval: report_interval,
-           reference_times: reference_times,
-           send_deltas: send_deltas,
-           rtts: rtts
-         } do
+    test "bumps estimated receive bandwidth after aggressive channel overuse", %{
+      cc: %CongestionControl{a_hat: initial_bwe} = cc,
+      n_reports: n_reports,
+      packets_per_report: packets_per_report,
+      report_interval: report_interval,
+      reference_times: reference_times,
+      send_deltas: send_deltas,
+      rtts: rtts
+    } do
       # when sending with a rate much higher than the bwe
       # we should finally overuse the connection;
       # this should result in changing the sate to `:decrease`
@@ -221,7 +220,7 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
       # be bumped by a lot
 
       rate = initial_bwe * 10
-      report_interval_ms = 200
+      report_interval_ms = Membrane.Time.to_milliseconds(report_interval)
       packet_size = rate * (report_interval_ms / 1000) / packets_per_report
 
       packet_sizes =

--- a/test/membrane/rtp/twcc_sender/congestion_control_test.exs
+++ b/test/membrane/rtp/twcc_sender/congestion_control_test.exs
@@ -245,7 +245,8 @@ defmodule Membrane.RTP.TWCCSender.CongestionControlTest do
         )
 
       assert cc.state == :decrease
-      assert_in_delta cc.a_hat / rate, 0.85, 0.95
+      assert cc.a_hat >= 0.80 * rate
+      assert cc.a_hat <= 0.95 * rate
     end
 
     test "starts to increase estimated receive bandwidth if interpacket delay decreases", %{

--- a/test/support/rtp_fixtures.ex
+++ b/test/support/rtp_fixtures.ex
@@ -51,7 +51,7 @@ defmodule Membrane.RTP.Fixtures do
 
     Enum.map(range, fn packet_number ->
       <<2::2, 0::1, 0::1, 0::4, 0::1, 14::7, base_seqnumber + packet_number::16,
-        base_timestamp + 30_000 * packet_number::32, ssrc::32, sample_packet_payload()::binary()>>
+        base_timestamp + 30_000 * packet_number::32, ssrc::32, sample_packet_payload()::binary>>
     end)
   end
 end


### PR DESCRIPTION
* selection between additive and multiplicative mode is now based on r_hats from the decrease state
* when decreasing bandwidth estimation, `last_r_hat` is used instead of `last_a_hat` i.e. `est = 0.85 * last_r_hat` 
