### PR TITLE
Support padding packets

### DIFF
--- a/lib/membrane/rtp/utils.ex
+++ b/lib/membrane/rtp/utils.ex
@@ -24,7 +24,8 @@ defmodule Membrane.RTP.Utils do
       0 ->
         {payload, 0}
 
-      padding_size ->
+      remainder ->
+        padding_size = align_to - remainder
         zeros_no = padding_size - 1
         {<<payload::binary, 0::size(zeros_no)-unit(8), padding_size>>, padding_size}
     end

--- a/test/membrane/rtp/outbound_tracking_serializer_test.exs
+++ b/test/membrane/rtp/outbound_tracking_serializer_test.exs
@@ -1,0 +1,31 @@
+defmodule Membrane.RTP.OutboundTrackingSerializerTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.Buffer
+  alias Membrane.RTP.OutboundTrackingSerializer
+
+  test "generates padding packets" do
+    serializer_state = %OutboundTrackingSerializer.State{}
+
+    buffer = %Buffer{
+      metadata: %{
+        rtp: %{
+          is_padding?: true,
+          ssrc: 1,
+          payload_type: 0,
+          marker: true,
+          extensions: [],
+          csrcs: [],
+          timestamp: 0,
+          sequence_number: 0
+        }
+      },
+      payload: <<>>
+    }
+
+    assert {{:ok, buffer: {:output, %Buffer{payload: payload}}}, _state} =
+             OutboundTrackingSerializer.handle_process(:input, buffer, nil, serializer_state)
+
+    assert byte_size(payload) == 256
+  end
+end


### PR DESCRIPTION
This PR adds support for generation of padding packets to RTP Plugin. This change is required to be able to publish a version of Membrane RTC Engine with automatic variant switching, as it needs to be able to probe the connection using padding packets.

Out of necessity, this PR also fixes `Membrane.RTP.Utils.align/2` function - it was incorrectly calculating the size of required padding as a `size % align_to` instead of `align_to - (size % align_to)`