### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtp_plugin` to your list of dep
 ```elixir
 def deps do
   [
-    {:membrane_rtp_plugin, "~> 0.15.0"}
+    {:membrane_rtp_plugin, "~> 0.16.0"}
     {:ex_libsrtp, "~> 0.3.0"} # required only if SRTP/SRTCP support is needed
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTP.Plugin.MixProject do
   use Mix.Project
 
-  @version "0.15.0"
+  @version "0.16.0"
   @github_url "https://github.com/membraneframework/membrane_rtp_plugin"
 
   def project do


### PR DESCRIPTION
Bump and release a new version before migrating to the new membrane_core (0.11.0)