### PR TITLE
[RTC-49] Send VAD as Event instead of notification

### DIFF
--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -4,11 +4,11 @@ defmodule Membrane.RTP.VAD do
 
   To make this module work appropriate RTP header extension has to be set in SDP offer/answer.
 
-  If avg of audio level in packets in `time_window` exceeds `vad_threshold` it emits
-  notification `t:speech_notification_t/0`.
+  If avg of audio level in packets in `time_window` exceeds `vad_threshold` it emits `Membrane.RTP.VAD.Event`
+  on its output pad.
 
   When avg falls below `vad_threshold` and doesn't exceed it in the next `vad_silence_timer`
-  it emits notification `t:silence_notification_t/0`.
+  it also emits the event.
 
   Buffers that are processed by this element may or may not have been processed by
   a depayloader and passed through a jitter buffer. If they have not, then the only timestamp
@@ -66,21 +66,11 @@ defmodule Membrane.RTP.VAD do
                 spec: pos_integer(),
                 default: 300,
                 description: """
-                Time to wait before emitting notification `t:silence_notification_t/0` after audio track is
+                Time to wait before emitting `Membrane.RTP.VAD.Event` after audio track is
                 no longer considered to represent speech.
-                If at this time audio track is considered to represent speech again the notification will not be sent.
+                If at this time audio track is considered to represent speech again the event will not be sent.
                 """
               ]
-
-  @typedoc """
-  Notification sent after detecting speech activity.
-  """
-  @type speech_notification_t() :: {:vad, :speech}
-
-  @typedoc """
-  Notification sent after detecting silence activity.
-  """
-  @type silence_notification_t() :: {:vad, :silence}
 
   @impl true
   def handle_init(opts) do
@@ -145,7 +135,7 @@ defmodule Membrane.RTP.VAD do
     state = filter_old_audio_levels(state)
     state = add_new_audio_level(state, level)
     audio_levels_vad = get_audio_levels_vad(state)
-    actions = [buffer: {:output, buffer}] ++ maybe_notify(audio_levels_vad, state)
+    actions = [buffer: {:output, buffer}] ++ maybe_send_event(audio_levels_vad, state)
     state = update_vad_state(audio_levels_vad, state)
     {{:ok, actions}, state}
   end
@@ -189,9 +179,9 @@ defmodule Membrane.RTP.VAD do
 
   defp avg(state), do: state.audio_levels_sum / state.audio_levels_count
 
-  defp maybe_notify(audio_levels_vad, state) do
+  defp maybe_send_event(audio_levels_vad, state) do
     if vad_silence?(audio_levels_vad, state) or vad_speech?(audio_levels_vad, state) do
-      [notify: {:vad, audio_levels_vad}]
+      [event: {:output, %__MODULE__.Event{vad: audio_levels_vad}}]
     else
       []
     end

--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -4,7 +4,7 @@ defmodule Membrane.RTP.VAD do
 
   To make this module work appropriate RTP header extension has to be set in SDP offer/answer.
 
-  If avg of audio level in packets in `time_window` exceeds `vad_threshold` it emits `Membrane.RTP.VAD.Event`
+  If avg of audio level in packets in `time_window` exceeds `vad_threshold` it emits `Membrane.RTP.VadEvent`
   on its output pad.
 
   When avg falls below `vad_threshold` and doesn't exceed it in the next `vad_silence_timer`
@@ -25,7 +25,7 @@ defmodule Membrane.RTP.VAD do
   """
   use Membrane.Filter
 
-  alias Membrane.RTP.{Header, Utils}
+  alias Membrane.RTP.{Header, Utils, VadEvent}
 
   def_input_pad :input, availability: :always, caps: :any, demand_mode: :auto
 
@@ -66,7 +66,7 @@ defmodule Membrane.RTP.VAD do
                 spec: pos_integer(),
                 default: 300,
                 description: """
-                Time to wait before emitting `Membrane.RTP.VAD.Event` after audio track is
+                Time to wait before emitting `Membrane.RTP.VadEvent` after audio track is
                 no longer considered to represent speech.
                 If at this time audio track is considered to represent speech again the event will not be sent.
                 """
@@ -181,7 +181,7 @@ defmodule Membrane.RTP.VAD do
 
   defp maybe_send_event(audio_levels_vad, state) do
     if vad_silence?(audio_levels_vad, state) or vad_speech?(audio_levels_vad, state) do
-      [event: {:output, %__MODULE__.Event{vad: audio_levels_vad}}]
+      [event: {:output, %VadEvent{vad: audio_levels_vad}}]
     else
       []
     end

--- a/lib/membrane/rtp/vad/event.ex
+++ b/lib/membrane/rtp/vad/event.ex
@@ -1,0 +1,19 @@
+defmodule Membrane.RTP.VAD.Event do
+  @moduledoc """
+  An event informing about Voice Activity Detection status changes
+  """
+
+  @derive Membrane.EventProtocol
+  @enforce_keys [:vad]
+  defstruct @enforce_keys
+
+  @typedoc """
+  Type describing the structure of the Voice Activity Detection event.
+
+  - `:vad` - contains information about VAD status. Indicates either speech or silence.
+    For details on voice activity detection algorithm, refer to `Membrane.RTP.VAD`
+  """
+  @type t() :: %__MODULE__{
+          vad: :speech | :silence
+        }
+end

--- a/lib/membrane/rtp/vad_event.ex
+++ b/lib/membrane/rtp/vad_event.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.RTP.VAD.Event do
+defmodule Membrane.RTP.VadEvent do
   @moduledoc """
   An event informing about Voice Activity Detection status changes
   """


### PR DESCRIPTION
This PR modifies the behavior of `Membrane.RTP.VAD` to send VAD information as events instead of notifications.
The usage of notifications causes problems by not synchronizing VAD notifications with buffers and doesn't fit well into `membrane_rtc_engine`.
Also, this change allows us to not inject the SSRC or other identifiers to VAD notifications.

I'm not quite sure if we should delete the notification or keep it and add an event alongside it.
I couldn't come up with any usecases where this could be a problem, so I deleted it for now, but I'm open to arguments why it should be restored.
