### PR TITLE
Replace buffer store with a map

### DIFF
--- a/lib/membrane/rtp/outbound_rtx_controller.ex
+++ b/lib/membrane/rtp/outbound_rtx_controller.ex
@@ -19,7 +19,7 @@ defmodule Membrane.RTP.OutboundRtxController do
   @min_rtx_interval 10
 
   @impl true
-  def handle_init(_opts), do: {:ok, %{store: %{}, last_rtx_times: %{}}}
+  def handle_init(_opts), do: {:ok, %{store: %{}}}
 
   # Ignores padding packets
   # TODO: Should it?

--- a/lib/membrane/rtp/outbound_rtx_controller.ex
+++ b/lib/membrane/rtp/outbound_rtx_controller.ex
@@ -26,7 +26,7 @@ defmodule Membrane.RTP.OutboundRtxController do
   @impl true
   def handle_process(:input, buffer, _ctx, state) when byte_size(buffer.payload) > 0 do
     idx = rem(buffer.metadata.rtp.sequence_number, @max_store_size)
-    state = put_in(state, [:store, idx], {System.monotonic_time(:millisecond), buffer})
+    state = put_in(state, [:store, idx], {nil, buffer})
     {{:ok, forward: buffer}, state}
   end
 
@@ -47,13 +47,14 @@ defmodule Membrane.RTP.OutboundRtxController do
         maybe_retransmit(seq_num, now, store)
       end)
 
-    buffers_to_retransmit = Enum.reject(buffers, fn buffer -> buffer == nil end)
+    buffers_to_retransmit = Enum.reject(buffers, &is_nil/1)
 
-    unless buffers_to_retransmit == [],
-      do:
-        Membrane.Logger.info(
-          "Retransmitting buffers (#{Enum.count(buffers_to_retransmit)}) with the following sequence numbers:\n#{inspect(Enum.map(buffers_to_retransmit, & &1.metadata.rtp.sequence_number))}"
-        )
+    unless buffers_to_retransmit == [] do
+      Membrane.Logger.info("""
+      Retransmitting (#{length(buffers_to_retransmit)}) buffers, sequence numbers:
+      #{inspect(Enum.map(buffers_to_retransmit, & &1.metadata.rtp.sequence_number))}
+      """)
+    end
 
     {{:ok, buffer: {:output, buffers_to_retransmit}}, %{state | store: store}}
   end
@@ -63,14 +64,17 @@ defmodule Membrane.RTP.OutboundRtxController do
 
   defp maybe_retransmit(seq_num, now, store) do
     idx = rem(seq_num, @max_store_size)
-    {last_rtx_timestamp, buffer} = Map.get(store, idx, {nil, nil})
+    {last_rtx_time, buffer} = Map.get(store, idx, {nil, nil})
 
     if buffer != nil and buffer.metadata.rtp.sequence_number == seq_num and
-         now - last_rtx_timestamp >= @min_rtx_interval do
-      store = Map.put(store, seq_num, {now, buffer})
+         time_elapsed?(last_rtx_time, now) do
+      store = Map.put(store, idx, {now, buffer})
       {buffer, store}
     else
       {nil, store}
     end
   end
+
+  defp time_elapsed?(nil, _now), do: true
+  defp time_elapsed?(last_rtx_time, now), do: now - last_rtx_time >= @min_rtx_interval
 end

--- a/lib/membrane/rtp/outbound_rtx_controller.ex
+++ b/lib/membrane/rtp/outbound_rtx_controller.ex
@@ -3,7 +3,6 @@ defmodule Membrane.RTP.OutboundRtxController do
 
   require Membrane.Logger
 
-  alias Membrane.RTP.JitterBuffer.BufferStore
   alias Membrane.RTP.RetransmissionRequest
 
   def_input_pad :input,
@@ -20,23 +19,15 @@ defmodule Membrane.RTP.OutboundRtxController do
   @min_rtx_interval 10
 
   @impl true
-  def handle_init(_opts), do: {:ok, %{store: BufferStore.new(), last_rtx_times: %{}}}
+  def handle_init(_opts), do: {:ok, %{store: %{}, last_rtx_times: %{}}}
 
   # Ignores padding packets
   # TODO: Should it?
   @impl true
   def handle_process(:input, buffer, _ctx, state) when byte_size(buffer.payload) > 0 do
-    state
-    |> Map.update!(:store, fn store ->
-      case BufferStore.insert_buffer(store, buffer) do
-        {:ok, new_store} ->
-          maintain_store_size(new_store)
-
-        {:error, :late_packet} ->
-          store
-      end
-    end)
-    |> then(&{{:ok, forward: buffer}, &1})
+    idx = rem(buffer.metadata.rtp.sequence_number, @max_store_size)
+    state = put_in(state, [:store, idx], {System.monotonic_time(:millisecond), buffer})
+    {{:ok, forward: buffer}, state}
   end
 
   @impl true
@@ -51,49 +42,35 @@ defmodule Membrane.RTP.OutboundRtxController do
       ) do
     now = System.monotonic_time(:millisecond)
 
-    buffers_to_retransmit =
-      sequence_numbers
-      |> Stream.map(fn seq_num -> BufferStore.get_buffer(state.store, seq_num) end)
-      |> Stream.filter(fn
-        {:ok, buffer} ->
-          seq_num = buffer.metadata.rtp.sequence_number
-          last_rtx_time = Map.get(state.last_rtx_times, seq_num, now - @min_rtx_interval)
-
-          now - last_rtx_time >= @min_rtx_interval
-
-        {:error, :not_found} ->
-          false
+    {buffers, store} =
+      Enum.map_reduce(sequence_numbers, state.store, fn seq_num, store ->
+        maybe_retransmit(seq_num, now, store)
       end)
-      |> Enum.map(fn {:ok, buffer} -> buffer end)
 
-    state =
-      Map.update!(state, :last_rtx_times, fn times ->
-        updates =
-          Map.new(buffers_to_retransmit, fn buffer ->
-            {buffer.metadata.rtp.sequence_number, now}
-          end)
-
-        Map.merge(times, updates)
-      end)
+    buffers_to_retransmit = Enum.reject(buffers, fn buffer -> buffer == nil end)
 
     unless buffers_to_retransmit == [],
       do:
         Membrane.Logger.info(
-          "Retransmitting buffers with the following sequence numbers:\n#{inspect(Enum.map(buffers_to_retransmit, & &1.metadata.rtp.sequence_number))}"
+          "Retransmitting buffers (#{Enum.count(buffers_to_retransmit)}) with the following sequence numbers:\n#{inspect(Enum.map(buffers_to_retransmit, & &1.metadata.rtp.sequence_number))}"
         )
 
-    {{:ok, buffer: {:output, buffers_to_retransmit}}, state}
+    {{:ok, buffer: {:output, buffers_to_retransmit}}, %{state | store: store}}
   end
 
   @impl true
   def handle_event(pad, event, ctx, state), do: super(pad, event, ctx, state)
 
-  defp maintain_store_size(store) do
-    if Enum.count(store) > @max_store_size do
-      {_entry, store} = BufferStore.flush_one(store)
-      maintain_store_size(store)
+  defp maybe_retransmit(seq_num, now, store) do
+    idx = rem(seq_num, @max_store_size)
+    {last_rtx_timestamp, buffer} = Map.get(store, idx, {nil, nil})
+
+    if buffer != nil and buffer.metadata.rtp.sequence_number == seq_num and
+         now - last_rtx_timestamp >= @min_rtx_interval do
+      store = Map.put(store, seq_num, {now, buffer})
+      {buffer, store}
     else
-      store
+      {nil, store}
     end
   end
 end


### PR DESCRIPTION
This implementation should be much more performant

blue and yellow metrics are multiplied by 1_000_000

Here is an example plot showing number of reductions when using BufferStore

![visualization (1)](https://user-images.githubusercontent.com/24651552/217483474-c1b7781b-d609-4abe-8c93-ed97ba6f2c3f.svg)


and here is a map
![visualization (2)](https://user-images.githubusercontent.com/24651552/217484164-84a223df-94ee-4b46-aaf0-32053a6fc7d6.svg)


While the x-axis differ a little, we can see that after 240s of talk we have ~37M of reductions vs 25M

In one case we still noticed some peaks for BufferStore. The overall number of reductions was also very high ~80M

![visualization (3)](https://user-images.githubusercontent.com/24651552/217484919-e167d061-9bd8-4ff6-a7da-47829c71f355.svg)
