### PR TITLE
Auth Fail

### DIFF
--- a/lib/membrane/srtp/decryptor.ex
+++ b/lib/membrane/srtp/decryptor.ex
@@ -109,7 +109,7 @@ if Code.ensure_loaded?(ExLibSRTP) do
           {{:ok, buffer: {:output, buffer}}, state}
 
         {:error, reason} when reason in [:auth_fail, :replay_fail, :replay_old] ->
-          Membrane.Logger.debug("""
+          Membrane.Logger.error("""
           Couldn't unprotect srtp packet:
           #{inspect(payload, limit: :infinity)}
           Reason: #{inspect(reason)}. Ignoring packet.

--- a/lib/membrane/srtp/decryptor.ex
+++ b/lib/membrane/srtp/decryptor.ex
@@ -108,7 +108,7 @@ if Code.ensure_loaded?(ExLibSRTP) do
 
           {{:ok, buffer: {:output, buffer}}, state}
 
-        {:error, reason} when reason in [:replay_fail, :replay_old] ->
+        {:error, reason} when reason in [:auth_fail, :replay_fail, :replay_old] ->
           Membrane.Logger.debug("""
           Couldn't unprotect srtp packet:
           #{inspect(payload, limit: :infinity)}


### PR DESCRIPTION
It seems that sometimes we receive `:auth_fail` error from SRTP Decryptor.
This is concerning, but may be caused by a late packet after SDP renegotiation.
It may be useful to not instantly crash the endpoint in this scenario and verify if `:auth_fail`s are not constant.
