### PR TITLE
Change output stream format to _any

### DIFF
--- a/lib/membrane/rtp/depayloader_bin.ex
+++ b/lib/membrane/rtp/depayloader_bin.ex
@@ -6,7 +6,6 @@ defmodule Membrane.RTP.DepayloaderBin do
 
   use Membrane.Bin
 
-  alias Membrane.RemoteStream
   alias Membrane.RTP
   alias Membrane.RTP.JitterBuffer
 
@@ -23,7 +22,7 @@ defmodule Membrane.RTP.DepayloaderBin do
     demand_unit: :buffers
 
   def_output_pad :output,
-    accepted_format: RemoteStream,
+    accepted_format: _any,
     demand_unit: :buffers
 
   @impl true


### PR DESCRIPTION
Since `Membrane.RTP.H264.Depayloader`, after the changes from [this PR](https://github.com/membraneframework/membrane_rtp_h264_plugin/pull/37), will output `Membrane.H264.RemoteStream` as opposed to simply `Membrane.RemoteStream`, changes ought to be made to allow it.

Discussion of this proposed solution is strongly encouraged, preferably in the linked PR.