### PR TITLE
Properly reinitiate RTP.VAD module

### DIFF
--- a/lib/membrane/rtp/vad.ex
+++ b/lib/membrane/rtp/vad.ex
@@ -83,7 +83,7 @@ defmodule Membrane.RTP.VAD do
         handle_vad(buffer, rtp_timestamp, level, state)
 
       rollover == :next ->
-        {[], state} = handle_init(%{}, state)
+        {[], state} = handle_init(%{}, %{state | vad_threshold: state.vad_threshold - 127})
         {[buffer: {:output, buffer}], state}
 
       true ->


### PR DESCRIPTION
RIght now each time handle_init is called `vad_threshold` by 127